### PR TITLE
fix: Use a tuple instead of number[] for RoamingEntity range

### DIFF
--- a/src/app/dw/DwGame.ts
+++ b/src/app/dw/DwGame.ts
@@ -40,6 +40,7 @@ import { Chest, ChestContentType } from './Chest';
 import { toLocationString, LocationString } from './LocationString';
 import {BaseState} from "./BaseState";
 import {EnemyData} from "./Enemy";
+import {RoamingEntityRange} from "./RoamingEntity";
 
 export type TiledMapMap = Record<string, DwMap>;
 
@@ -417,13 +418,19 @@ export class DwGame extends Game {
         });
     }
 
-    private parseRange(rangeStr?: string): number[] | undefined {
-        let range: number[] | undefined;
+    private parseRange(rangeStr?: string): RoamingEntityRange | undefined {
+        let range: RoamingEntityRange | undefined;
         if (rangeStr) {
             const temp: string[] = rangeStr.split(/,\s*/);
-            range = temp.map((value: string) => {
-                return parseInt(value, 10);
-            });
+            if (temp.length !== 4) {
+                throw new Error(`Invalid range string: ${rangeStr}`);
+            }
+            range = {
+                minCol: parseInt(temp[0], 10),
+                minRow: parseInt(temp[1], 10),
+                maxCol: parseInt(temp[2], 10),
+                maxRow: parseInt(temp[3], 10),
+            };
         }
         return range;
     }

--- a/src/app/dw/RoamingEntity.ts
+++ b/src/app/dw/RoamingEntity.ts
@@ -3,12 +3,19 @@ import { Direction } from './Direction';
 import { DwGame } from './DwGame';
 import { Hero } from './Hero';
 
+export interface RoamingEntityRange {
+    minRow: number;
+    maxRow: number;
+    minCol: number;
+    maxCol: number;
+}
+
 export interface RoamingEntityArgs {
     name: string;
     direction?: number;
     mapRow?: number;
     mapCol?: number;
-    range?: number[];
+    range?: RoamingEntityRange;
 }
 
 export class RoamingEntity {
@@ -20,7 +27,7 @@ export class RoamingEntity {
     mapCol: number;
     xOffs: number;
     yOffs: number;
-    private readonly range?: number[];
+    private readonly range?: RoamingEntityRange;
     protected stepTick: number;
     private moveInc: number;
 
@@ -86,8 +93,8 @@ export class RoamingEntity {
      */
     private isOutOfRange(row: number, col: number) {
         if (this.range) {
-            return col < this.range[0] || col > this.range[2] ||
-                row < this.range[1] || row > this.range[3];
+            return col < this.range.minCol || col > this.range.maxCol ||
+                row < this.range.minRow || row > this.range.maxRow;
         }
         return false;
     }


### PR DESCRIPTION
This improves code readability and appeases some `tsc` errors if we ever try to enable `noUncheckedIndexedAccess` (which is unfortunately really difficult right now due to many other issues).