### PR TITLE
refactor: ItemBubble should subclass ChoiceBubble

### DIFF
--- a/src/app/dw/ChoiceBubble.ts
+++ b/src/app/dw/ChoiceBubble.ts
@@ -2,27 +2,24 @@ import { InputManager } from 'gtp';
 import { Bubble } from './Bubble';
 import { DwGame } from "./DwGame";
 
-type ChoiceBubbleStringMap = Record<string, string>;
-export type ChoiceBubbleChoice = string | ChoiceBubbleStringMap;
-
 /**
  * A bubble that lets the user choose between several choices.
  */
 export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
 
     private readonly choices: ChoiceBubbleChoice[];
-    private readonly choiceDisplayField?: string;
+    private readonly choiceStringifier: (choice: ChoiceBubbleChoice) => string;
     private curChoice: number;
     private readonly cancellable: boolean;
 
     constructor(game: DwGame, x: number, y: number, w: number, h: number,
         choices: ChoiceBubbleChoice[] = [],
-        choiceDisplayField?: string,
+        choiceStringifier?: (choice: ChoiceBubbleChoice) => string,
         cancellable = false,
         title: string | undefined = undefined) {
         super(game, title, x, y, w, h);
         this.choices = choices;
-        this.choiceDisplayField = choiceDisplayField;
+        this.choiceStringifier = choiceStringifier ?? ((choice: ChoiceBubbleChoice) => choice as unknown as string);
         this.cancellable = cancellable;
         this.curChoice = 0;
     }
@@ -79,19 +76,12 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
             if (this.curChoice === index) {
                 this.drawArrow(this.x + Bubble.MARGIN, y);
             }
-            this.game.drawString(this.stringify(choice), x, y);
+            this.game.drawString(this.choiceStringifier(choice), x, y);
             y += 18 * this.game.scale;
         });
     }
 
     reset() {
         this.curChoice = 0;
-    }
-
-    private stringify(choice: ChoiceBubbleChoice): string {
-        if (this.choiceDisplayField) {
-            return (choice as ChoiceBubbleStringMap)[this.choiceDisplayField];
-        }
-        return choice as unknown as string;
     }
 }

--- a/src/app/dw/ItemBubble.ts
+++ b/src/app/dw/ItemBubble.ts
@@ -1,13 +1,8 @@
-import { InputManager } from 'gtp';
 import { DwGame } from './DwGame';
-import { Bubble } from './Bubble';
-import { Item } from './Item';
 import { ItemCountPair } from './Inventory';
+import { ChoiceBubble } from "@/app/dw/ChoiceBubble";
 
-export class ItemBubble extends Bubble {
-
-    private readonly choices: ItemCountPair[];
-    private curChoice: number;
+export class ItemBubble extends ChoiceBubble<ItemCountPair> {
 
     constructor(game: DwGame) {
 
@@ -17,51 +12,8 @@ export class ItemBubble extends Bubble {
         const h: number = 100 * scale;
         const x: number = 9 * tileSize;
         const y: number = 3 * tileSize;
-        super(game, undefined, x, y, w, h);
 
-        this.choices = game.party.getInventory().getItems();
-        this.curChoice = 0;
-    }
-
-    getSelectedItem(): Item | undefined {
-        return this.curChoice > -1 ? this.choices[this.curChoice].item : undefined;
-    }
-
-    handleInput() {
-
-        const im: InputManager = this.game.inputManager;
-
-        if (this.game.cancelKeyPressed()) {
-            this.curChoice = -1;
-            return true;
-        } else if (this.game.actionKeyPressed()) {
-            return true;
-        } else if (im.up(true)) {
-            this.curChoice = Math.max(0, this.curChoice - 1);
-            this.resetArrowTimer();
-        } else if (im.down(true)) {
-            this.curChoice = Math.min(this.curChoice + 1, this.choices.length - 1);
-            this.resetArrowTimer();
-        }
-
-        return false;
-    }
-
-    override paintContent(ctx: CanvasRenderingContext2D, x: number, y: number) {
-
-        ctx.fillStyle = 'rgb(255,255,255)';
-        this.choices.forEach((choice, index) => {
-            if (this.curChoice === index) {
-                this.drawArrow(this.x + Bubble.MARGIN, y);
-            }
-            this.game.drawString(choice.item.displayName, x, y);
-            y += 10 * this.game.scale;
-        });
-    }
-
-    removeSelectedItem() {
-        if (this.curChoice > -1) {
-            this.choices.splice(this.curChoice, 1);
-        }
+        const choices = game.party.getInventory().getItems();
+        super(game, x, y, w, h, choices, (choice) => choice.item.name);
     }
 }

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -195,10 +195,9 @@ export class RoamingState extends BaseState {
             this.itemBubble.update(delta);
             done = this.itemBubble.handleInput();
             if (done) {
-                const selectedItem: Item | undefined = this.itemBubble.getSelectedItem();
+                const selectedItem: Item | undefined = this.itemBubble.getSelectedItem()?.item;
                 const success: boolean = !selectedItem || selectedItem.use(this.game); // Either canceled the dialog or selected item
                 if (success) {
-                    this.itemBubble.removeSelectedItem();
                     this.setSubstate('ROAMING');
                 }
                 delete this.itemBubble;

--- a/src/app/dw/TextBubble.ts
+++ b/src/app/dw/TextBubble.ts
@@ -96,7 +96,12 @@ export class TextBubble extends Bubble {
         const width: number = tileSize * 5;
         const height: number = tileSize * (choices.length + 1);
 
-        return new ChoiceBubble(this.game, x, y, width, height, choices, 'text');
+        return new ChoiceBubble(this.game, x, y, width, height, choices, (choice) => {
+            if (typeof choice === 'string') {
+                return choice;
+            }
+            return choice.text;
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #27. This is a small refactor to reuse some code. I originally wanted to just remove the `ItemBubble` class altogether, but since bubbles have hard-coded bounds, it was easier just to have a subclass that configures its position and size. It still removed some duplicated code.