### PR TITLE
feat: Add searching for hidden items

### DIFF
--- a/public/res/maps/brecconary.json
+++ b/public/res/maps/brecconary.json
@@ -151,6 +151,34 @@
         }, 
         {
          "draworder":"topdown",
+         "id":6,
+         "name":"hiddenItemLayer",
+         "objects":[
+                {
+                 "height":16,
+                 "id":17,
+                 "name":"testHiddenItem",
+                 "properties":[
+                        {
+                         "name":"item",
+                         "type":"string",
+                         "value":"herb"
+                        }],
+                 "rotation":0,
+                 "type":"item",
+                 "visible":true,
+                 "width":16,
+                 "x":48,
+                 "y":304
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
          "id":4,
          "name":"warpLayer",
          "objects":[
@@ -525,8 +553,8 @@
          "x":0,
          "y":0
         }],
- "nextlayerid":6,
- "nextobjectid":17,
+ "nextlayerid":9,
+ "nextobjectid":18,
  "orientation":"orthogonal",
  "properties":[
         {

--- a/public/res/maps/dw.tiled-session
+++ b/public/res/maps/dw.tiled-session
@@ -18,11 +18,15 @@
             }
         },
         "brecconary.json": {
+            "expandedObjectLayers": [
+                5,
+                6
+            ],
             "scale": 1,
-            "selectedLayer": 4,
+            "selectedLayer": 3,
             "viewCenter": {
-                "x": 165.5,
-                "y": 279
+                "x": 206.5,
+                "y": 285
             }
         },
         "brecconary.tmx": {
@@ -148,6 +152,9 @@
             "scaleInDock": 1
         },
         "tantegelCastle.json": {
+            "expandedObjectLayers": [
+                4
+            ],
             "scale": 1.3635,
             "selectedLayer": 3,
             "viewCenter": {

--- a/src/app/dw/Chest.ts
+++ b/src/app/dw/Chest.ts
@@ -3,6 +3,10 @@ import { LocationString } from './LocationString';
 // TODO: Can this be pulled from/match items somehow?
 export type ChestContentType = 'gold' | 'magicKey';
 
+/**
+ * Denotes a treasure chest on the map. This is pulled from the "npcLayer" in the Tiled map data,
+ * but is stored directly in the "DwMap" for simplicity.
+ */
 export interface Chest {
     id: string;
     contentType: ChestContentType;

--- a/src/app/dw/ChestConversations.ts
+++ b/src/app/dw/ChestConversations.ts
@@ -1,13 +1,18 @@
 import { Chest } from './Chest';
 import { RoamingState } from './RoamingState';
 import { Conversation } from './Conversation';
+import { LocationString, toLocationString } from '@/app/dw/LocationString';
 
 /**
  * Returns the text to display when the player opens a treasure chest.
  */
-export const getChestConversation = (state: RoamingState, chest: Chest | undefined): Conversation => {
+export const getChestConversation = (state: RoamingState): Conversation => {
 
-    const conversation: Conversation = new Conversation(state.game, false);
+    const game = state.game;
+    const location: LocationString = toLocationString(game.hero.mapRow, game.hero.mapCol);
+    const chest: Chest | undefined = game.getMap().chests.get(location);
+
+    const conversation: Conversation = new Conversation(game, false);
 
     if (!chest) {
         conversation.addSegment('There is nothing to do here, \\w{hero.name}.');
@@ -24,8 +29,8 @@ export const getChestConversation = (state: RoamingState, chest: Chest | undefin
                 sound: 'openChest',
                 text: `Of GOLD thou hast gained ${gold}.`,
                 action: () => {
-                    state.game.removeChest(chest);
-                    state.game.party.gold += gold;
+                    game.removeChest(chest);
+                    game.party.gold += gold;
                 },
             });
             break;
@@ -35,7 +40,7 @@ export const getChestConversation = (state: RoamingState, chest: Chest | undefin
                 sound: 'openChest',
                 text: 'Fortune smiles upon thee, \\w{hero.name}.',
                 action: () => {
-                    state.game.removeChest(chest);
+                    game.removeChest(chest);
                 },
             });
             conversation.addSegment('Thou hast found the Magic Key');

--- a/src/app/dw/DwGameState.ts
+++ b/src/app/dw/DwGameState.ts
@@ -1,4 +1,5 @@
 export interface MapState {
+    obtainedHiddenItems: string[];
     openedChests: string[];
     unlockedDoors: string[];
 }
@@ -12,8 +13,9 @@ export interface DwGameState {
     mapStates: MapStateMap;
 }
 
-const createEmtpyMapState = (): MapState => {
+const createEmptyMapState = (): MapState => {
     return {
+        obtainedHiddenItems: [],
         openedChests: [],
         unlockedDoors: [],
     };
@@ -22,7 +24,10 @@ const createEmtpyMapState = (): MapState => {
 export const createDefaultGameState = (): DwGameState => {
     return {
         mapStates: {
-            tantegelCastle: createEmtpyMapState(),
+            brecconary: createEmptyMapState(),
+            garinham: createEmptyMapState(),
+            overworld: createEmptyMapState(),
+            tantegelCastle: createEmptyMapState(),
         },
     };
 };

--- a/src/app/dw/DwMap.ts
+++ b/src/app/dw/DwMap.ts
@@ -3,6 +3,7 @@ import { Npc } from './Npc';
 import { Door } from './Door';
 import { Chest } from './Chest';
 import { LocationString } from './LocationString';
+import { HiddenItem } from './HiddenItem';
 
 export class DwMap extends TiledMap {
 
@@ -10,6 +11,7 @@ export class DwMap extends TiledMap {
     readonly talkAcrosses: Map<LocationString, boolean>;
     readonly doors: Door[];
     readonly chests: Map<LocationString, Chest>;
+    readonly hiddenItems: Map<LocationString, HiddenItem>;
 
     constructor(public name: string, data: TiledMapData, args: TiledMapArgs) {
         super(data, args);
@@ -17,9 +19,14 @@ export class DwMap extends TiledMap {
         this.talkAcrosses = new Map();
         this.doors = [];
         this.chests = new Map();
+        this.hiddenItems = new Map();
     }
 
     removeChest(chest: Chest) {
         this.chests.delete(chest.location);
+    }
+
+    removeHiddenItem(item: HiddenItem) {
+        this.hiddenItems.delete(item.location);
     }
 }

--- a/src/app/dw/HiddenItem.ts
+++ b/src/app/dw/HiddenItem.ts
@@ -1,0 +1,15 @@
+import { LocationString } from './LocationString';
+import { Item } from "./Item";
+
+export type HiddenItemType = 'herb';
+
+/**
+ * Denotes a hidden item on the map. This is pulled from the "hiddenItemLayer" in the Tiled map data,
+ * but is stored directly in the "DwMap" for simplicity.
+ */
+export interface HiddenItem {
+    id: string;
+    contentType: HiddenItemType;
+    contents: Item;
+    location: LocationString;
+}

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -16,8 +16,9 @@ import { ChoiceBubble } from './ChoiceBubble';
 import { Door } from './Door';
 import { DwMap } from './DwMap';
 import { Chest } from './Chest';
-import { toLocationString, LocationString, toRowAndColumn } from './LocationString';
+import { toRowAndColumn } from './LocationString';
 import { getChestConversation } from './ChestConversations';
+import { getSearchConversation } from './SearchConversations';
 
 type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION';
 
@@ -68,29 +69,14 @@ export class RoamingState extends BaseState {
     }
 
     search() {
-
-        const messages: string[] = [ '\\w{hero.name} searched the ground all about.' ];
-
-        const heroPos: LocationString = toLocationString(this.game.hero.mapRow, this.game.hero.mapCol);
-        const chest: boolean = this.game.getMap().chests.has(heroPos);
-
-        // In this game, you must "TAKE" treasure, not "SEARCH" for it.
-        if (chest) {
-            messages.push('There is a treasure box.');
-        } else {
-            messages.push('But there found nothing.');
-        }
-
-        this.showOneLineConversation(false, ...messages);
+        this.showTextBubble = true;
+        this.textBubble.setConversation(getSearchConversation(this));
+        this.setSubstate('TALKING');
     }
 
     take() {
-
-        const location: LocationString = toLocationString(this.game.hero.mapRow, this.game.hero.mapCol);
-        const chest: Chest | undefined = this.game.getMap().chests.get(location);
-
         this.showTextBubble = true;
-        this.textBubble.setConversation(getChestConversation(this, chest));
+        this.textBubble.setConversation(getChestConversation(this));
         this.setSubstate('TALKING');
     }
 

--- a/src/app/dw/SearchConversations.ts
+++ b/src/app/dw/SearchConversations.ts
@@ -1,0 +1,49 @@
+import { RoamingState } from './RoamingState';
+import { Conversation } from './Conversation';
+import { LocationString, toLocationString } from "@/app/dw/LocationString";
+import { HERB } from "@/app/dw/Item";
+
+/**
+ * Returns the text to display when the player opens a treasure chest.
+ */
+export const getSearchConversation = (state: RoamingState): Conversation => {
+
+    const conversation: Conversation = new Conversation(state.game, false);
+    const game = state.game;
+    conversation.addSegment('\\w{hero.name} searched the ground all about.');
+
+    const location: LocationString = toLocationString(game.hero.mapRow, game.hero.mapCol);
+    const chest: boolean = game.getMap().chests.has(location);
+
+    // In this game, you must "TAKE" treasure, not "SEARCH" for it.
+    if (chest) {
+        conversation.addSegment('There is a treasure box.');
+        return conversation;
+    }
+
+    const hiddenItem = game.getMap().hiddenItems.get(location);
+    if (!hiddenItem) {
+        conversation.addSegment('But there found nothing.');
+        return conversation;
+    }
+
+    switch (hiddenItem.contentType) {
+        case 'herb':
+            conversation.addSegment({
+                text: 'You found an herb!',
+                action: () => {
+                    game.removeHiddenItem(hiddenItem);
+                    game.party.addInventoryItem(HERB);
+                },
+            });
+            break;
+
+        default:
+            // TODO: See if we can validate at map load time and print better errors, e.g. unsupported value
+            console.error(`Bad map data: unsupported hiddenItem type at ${hiddenItem.location}!`);
+            conversation.addSegment('There is nothing to do here, \\w{hero.name}.');
+            break;
+    }
+
+    return conversation;
+};


### PR DESCRIPTION
Fixes #31.

* The `SEARCH` menu action now looks for "hidden" items in a new map layer, `hiddenItemLayer`
* The `brecconary.json` map now has a test hidden item that can be obtained, near the west entrance
* Maps and game states now have the concept of "obtained" hidden items, though it's complete

### Screenshots:

| <img width="543" height="474" alt="image" src="https://github.com/user-attachments/assets/e0241c3a-ad88-4814-a664-541a4aedbbcf" /> |
| --- |
| Finding a hidden item |
