### PR TITLE
fix: Don't group identical inventory items

### DIFF
--- a/src/app/dw/Inventory.ts
+++ b/src/app/dw/Inventory.ts
@@ -1,29 +1,22 @@
 import { Item, getItemByName } from './Item';
-
-export interface ItemCountPair {
-    item: Item;
-    count: number;
-}
+import { Party } from '@/app/dw/Party';
 
 export class Inventory {
 
-    private readonly items: Map<Item, number>;
+    private readonly items: Item[];
 
     constructor() {
-        this.items = new Map<Item, number>();
+        this.items = [];
     }
 
-    getItems(): ItemCountPair[] {
-        const items: ItemCountPair[] = [];
-        this.items.forEach((value: number, key: Item) => {
-            items.push({ item: key, count: value });
-        });
-        return items;
+    getItems(): Item[] {
+        return this.items.slice();
     }
 
     push(item: Item) {
-        const count = this.items.get(item) ?? 0;
-        this.items.set(item, count + 1);
+        if (this.items.length < Party.INVENTORY_MAX_SIZE) {
+            this.items.push(item);
+        }
     }
 
     remove(itemName: string): boolean {
@@ -33,13 +26,9 @@ export class Inventory {
             return false;
         }
 
-        const count = this.items.get(item) ?? 0;
-        if (count > 0) {
-            if (count === 1) {
-                this.items.delete(item);
-            } else {
-                this.items.set(item, count - 1);
-            }
+        const index = this.items.indexOf(item);
+        if (index > -1) {
+            this.items.splice(index, 1);
             return true;
         }
         return false;
@@ -50,10 +39,10 @@ export class Inventory {
      * this inventory (NOT the total number of items!).
      */
     getItemTypeCount(): number {
-        return this.items.size;
+        return this.items.length;
     }
 
     toString(): string {
-        return `[Inventory: size=${this.items.size}]`;
+        return `[Inventory: size=${this.items.length}]`;
     }
 }

--- a/src/app/dw/ItemBubble.ts
+++ b/src/app/dw/ItemBubble.ts
@@ -1,8 +1,8 @@
 import { DwGame } from './DwGame';
-import { ItemCountPair } from './Inventory';
 import { ChoiceBubble } from "@/app/dw/ChoiceBubble";
+import { Item } from '@/app/dw/Item';
 
-export class ItemBubble extends ChoiceBubble<ItemCountPair> {
+export class ItemBubble extends ChoiceBubble<Item> {
 
     constructor(game: DwGame) {
 
@@ -14,6 +14,6 @@ export class ItemBubble extends ChoiceBubble<ItemCountPair> {
         const y: number = 3 * tileSize;
 
         const choices = game.party.getInventory().getItems();
-        super(game, x, y, w, h, choices, (choice) => choice.item.name);
+        super(game, x, y, w, h, choices, (choice) => choice.name);
     }
 }

--- a/src/app/dw/Party.ts
+++ b/src/app/dw/Party.ts
@@ -23,6 +23,8 @@ export class Party {
         this.gold = 768;
         this.inventory.push(KEY);
         this.inventory.push(TORCH);
+        this.inventory.push(KEY);
+        this.inventory.push(TORCH);
     }
 
     /**

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -181,8 +181,19 @@ export class RoamingState extends BaseState {
             this.itemBubble.update(delta);
             done = this.itemBubble.handleInput();
             if (done) {
-                const selectedItem: Item | undefined = this.itemBubble.getSelectedItem()?.item;
-                const success: boolean = !selectedItem || selectedItem.use(this.game); // Either canceled the dialog or selected item
+                let success = false;
+                const selectedItem: Item | undefined = this.itemBubble.getSelectedItem();
+
+                if (selectedItem) {
+                    success = selectedItem.use(this.game);
+                    if (success) {
+                        this.game.getParty().getInventory().remove(selectedItem.name);
+                    }
+                } else {
+                    // Either canceled the dialog or selected item
+                    success = true;
+                }
+
                 if (success) {
                     this.setSubstate('ROAMING');
                 }


### PR DESCRIPTION
The party's inventory should just be a raw list of items, not a list of `(item, count)` pairs. That might happen in later games but not in DQ1.