### PR TITLE
fix: Make ItemBubble cancellable

### DIFF
--- a/src/app/dw/Inventory.ts
+++ b/src/app/dw/Inventory.ts
@@ -13,6 +13,13 @@ export class Inventory {
         return this.items.slice();
     }
 
+    /**
+     * Returns the number of items in the inventory.
+     */
+    getSize(): number {
+        return this.items.length;
+    }
+
     push(item: Item) {
         if (this.items.length < Party.INVENTORY_MAX_SIZE) {
             this.items.push(item);
@@ -32,14 +39,6 @@ export class Inventory {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Returns the number of different types of items in
-     * this inventory (NOT the total number of items!).
-     */
-    getItemTypeCount(): number {
-        return this.items.length;
     }
 
     toString(): string {

--- a/src/app/dw/ItemBubble.ts
+++ b/src/app/dw/ItemBubble.ts
@@ -6,14 +6,15 @@ export class ItemBubble extends ChoiceBubble<Item> {
 
     constructor(game: DwGame) {
 
-        const scale: number = game.scale;
         const tileSize: number = game.getTileSize();
-        const w: number = 7 * tileSize;
-        const h: number = 100 * scale;
         const x: number = 9 * tileSize;
         const y: number = 3 * tileSize;
 
+        const inventorySize = game.getParty().getInventory().getSize();
+        const w: number = 7 * tileSize;
+        const h: number = (inventorySize + 2) * tileSize;
+
         const choices = game.party.getInventory().getItems();
-        super(game, x, y, w, h, choices, (choice) => choice.name);
+        super(game, x, y, w, h, choices, (choice) => choice.name, true);
     }
 }

--- a/src/app/dw/Party.ts
+++ b/src/app/dw/Party.ts
@@ -4,7 +4,7 @@
 import { DwGame } from './DwGame';
 import { PartyMember } from './PartyMember';
 import { Inventory } from './Inventory';
-import { Item, KEY, TORCH } from './Item';
+import { HERB, Item, KEY, TORCH } from './Item';
 
 export class Party {
 
@@ -25,6 +25,8 @@ export class Party {
         this.inventory.push(TORCH);
         this.inventory.push(KEY);
         this.inventory.push(TORCH);
+        this.inventory.push(HERB);
+        this.inventory.push(HERB);
     }
 
     /**
@@ -105,7 +107,7 @@ export class Party {
      * @see #getInventory()
      */
     isInventoryFull(): boolean {
-        return this.inventory.getItemTypeCount() >= Party.INVENTORY_MAX_SIZE;
+        return this.inventory.getSize() >= Party.INVENTORY_MAX_SIZE;
     }
 
     /**

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -190,8 +190,8 @@ export class RoamingState extends BaseState {
                         this.game.getParty().getInventory().remove(selectedItem.name);
                     }
                 } else {
-                    // Either canceled the dialog or selected item
-                    success = true;
+                    // Either canceled the dialog or selected item is unimplemented
+                    success = false;
                 }
 
                 if (success) {


### PR DESCRIPTION
Currently, if the user opens the ite bubble via the `item` menu, they can't close it without selecting an item. This PR makes the cancel button (i.e. `X`) close it and go back to the prior step (the main action menu).