### PR TITLE
fix: Command bubble display behavior

### DIFF
--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -158,7 +158,7 @@ export class RoamingState extends BaseState {
             } else {
                 this.setSubstate('MENU');
             }
-            this.warpBubble = undefined;
+            delete this.cheatBubble;
         }
     }
 
@@ -411,7 +411,7 @@ export class RoamingState extends BaseState {
             ctx.restore();
         }
 
-        if (this.substate === 'MENU' || this.substate === 'WARP_SELECTION' || this.substate === 'CHEAT_SELECTION') {
+        if (this.substate !== 'ROAMING') {
             this.commandBubble.paint(ctx);
         }
 
@@ -457,10 +457,9 @@ export class RoamingState extends BaseState {
     private setSubstate(substate: RoamingSubState) {
         const prevSubstate: RoamingSubState = this.substate;
         this.substate = substate;
-        if (substate === 'MENU') {
+        if (substate === 'MENU' && prevSubstate === 'ROAMING') {
             this.commandBubble.init();
-        } else if (substate === 'TALKING' &&
-          prevSubstate !== 'OVERNIGHT') {
+        } else if (substate === 'TALKING' && prevSubstate !== 'OVERNIGHT') {
             this.textBubble.init();
         }
     }


### PR DESCRIPTION
Fixes #84.

The `CHEAT*` and `WARP*` bubbles should not trigger a reload of the underlying `COMMAND` bubble when they are closed without taking action.

This PR also keeps the `COMMAND` bubble visible when talking or visiting an inn, to better match the real game's behavior. Because of our extra menu items, the command bubble is a little large and it takes away from seeing the tiles immediately around the hero, but for now, it is what it is - these extra actions are too useful for development.