### PR TITLE
feat: Cast Heal/Hurt while roaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/parser": "8.48.0",
         "@vitest/coverage-v8": "4.0.16",
         "@vitest/eslint-plugin": "1.5.2",
+        "canvas": "3.2.0",
         "eslint": "9.39.1",
         "eslint-plugin-import": "2.32.0",
         "jsdom": "27.3.0",
@@ -2121,6 +2122,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2131,6 +2153,18 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2139,6 +2173,31 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind": {
@@ -2201,6 +2260,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -2227,6 +2302,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2392,6 +2474,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2435,6 +2543,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2461,6 +2579,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -3014,6 +3142,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3129,6 +3267,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3252,6 +3397,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.0",
@@ -3511,6 +3663,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3547,6 +3720,20 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4227,6 +4414,19 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4263,6 +4463,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4289,10 +4496,37 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
+      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4403,6 +4637,16 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4615,6 +4859,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4625,6 +4896,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4633,6 +4915,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4801,6 +5124,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -5025,6 +5369,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5061,6 +5452,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -5178,6 +5579,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5292,6 +5723,19 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -5452,6 +5896,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.0",
@@ -5799,6 +6250,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/parser": "8.48.0",
     "@vitest/coverage-v8": "4.0.16",
     "@vitest/eslint-plugin": "1.5.2",
+    "canvas": "3.2.0",
     "eslint": "9.39.1",
     "eslint-plugin-import": "2.32.0",
     "jsdom": "27.3.0",

--- a/public/res/maps/dw.tiled-session
+++ b/public/res/maps/dw.tiled-session
@@ -19,14 +19,14 @@
         },
         "brecconary.json": {
             "expandedObjectLayers": [
-                5,
-                6
+                6,
+                5
             ],
             "scale": 6.9708,
-            "selectedLayer": -1,
+            "selectedLayer": 0,
             "viewCenter": {
-                "x": 31.20158374935445,
-                "y": 294.80117059734897
+                "x": 311.94410971481034,
+                "y": 303.9823262753199
             }
         },
         "brecconary.tmx": {
@@ -49,8 +49,8 @@
             "scale": 1,
             "selectedLayer": 0,
             "viewCenter": {
-                "x": 161.5,
-                "y": 159
+                "x": 159.5,
+                "y": 160
             }
         },
         "erdricksCave1.json#collision": {
@@ -77,8 +77,8 @@
             "scale": 1,
             "selectedLayer": 0,
             "viewCenter": {
-                "x": 160.5,
-                "y": 159
+                "x": 159.5,
+                "y": 160
             }
         },
         "erdricksCave2.json#collision": {
@@ -105,8 +105,8 @@
             "scale": 1,
             "selectedLayer": 0,
             "viewCenter": {
-                "x": 233.5,
-                "y": 225
+                "x": 231.5,
+                "y": 224
             }
         },
         "garinham.json#collision": {
@@ -158,8 +158,8 @@
             "scale": 1.3635,
             "selectedLayer": 3,
             "viewCenter": {
-                "x": 72.24055738907222,
-                "y": 263.2929959662633
+                "x": 336.2669600293363,
+                "y": 319.76530986431976
             }
         },
         "tantegelCastle.tmx": {
@@ -174,8 +174,8 @@
             "scale": 1.3118,
             "selectedLayer": 2,
             "viewCenter": {
-                "x": 197.05747827412716,
-                "y": 193.62707729836868
+                "x": 191.72129897850283,
+                "y": 171.52004878792502
             }
         },
         "tileset_tiles.json": {

--- a/src/app/dw/BattleState.ts
+++ b/src/app/dw/BattleState.ts
@@ -96,7 +96,8 @@ Thy gold increases by ${this.enemy.gp}.`;
 
         if (result.type === 'physical') {
             const text = `The ${this.enemy.name} attacks!`;
-            this.textBubble.addToConversation({ text, afterSound: 'prepareToAttack' }, true);
+            this.textBubble.addToConversation({ text,
+                afterSound: 'prepareToAttack' }, true);
             this.textBubble.onDone(() => {
                 this.enemyAttackDelay = new Delay({
                     millis: 350,

--- a/src/app/dw/Bubble.ts
+++ b/src/app/dw/Bubble.ts
@@ -95,8 +95,8 @@ export class Bubble {
     static removeSpecialEscapes(text: string, delays: BreakApartDelay[]) {
 
         // Delay formats:
-        //    \d      - default ms
-        //    \d- 300 ms
+        //    \d{750} - 750ms
+        //    \d      - default (500ms)
 
         let delay: number;
         let index: number;

--- a/src/app/dw/ChoiceBubble.ts
+++ b/src/app/dw/ChoiceBubble.ts
@@ -57,6 +57,7 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
             this.curChoice = 0;
             this.resetArrowTimer();
         } else if (this.game.actionKeyPressed()) {
+            this.game.audio.playSound('menu');
             return true;
         } else if (im.up(true)) {
             this.curChoice = Math.max(0, this.curChoice - 1);

--- a/src/app/dw/Conversation.ts
+++ b/src/app/dw/Conversation.ts
@@ -5,6 +5,17 @@ import { NpcText } from './mapLogic/MapLogic';
 import { DwGame } from './DwGame';
 import { Sellable } from './Sellable';
 
+/**
+ * Conversations track everything an NPC says to the hero, along with events to trigger along the way -
+ * sounds to play, actions to perform, etc. Conversations are usually loaded from the <code>mapLogic</code> folder.
+ * A common pattern is:
+ *
+ * <code>
+ * const conversation = new Conversation(game, true);
+ * conversation.setSegments(mapLogic.npcText(npc, game));
+ * // or, conversation.addSegment(singleSegment);
+ * </code>
+ */
 export class Conversation {
 
     private readonly voice: boolean;
@@ -59,8 +70,7 @@ export class Conversation {
     /**
      * Adds one or more segments to this conversation.
      *
-     * @param segmentArgs Either a single segment argument map, or
-     *        an array of them.
+     * @param segmentArgs The new conversation information.
      */
     setSegments(segmentArgs: NpcText) {
 
@@ -122,23 +132,17 @@ export class Conversation {
         return this.getNextIndex() < this.segments.length;
     }
 
-    current(performAction = false): ConversationSegment | null {
+    current(): ConversationSegment | null {
         const segment: ConversationSegment | null = this.segmentIndex >= this.segments.length ? null :
             this.segments[this.segmentIndex];
-        if (performAction && segment?.action) {
-            segment.action();
-        }
         return segment;
     }
 
-    next(performAction: boolean): ConversationSegment | null {
+    next(): ConversationSegment | null {
         const nextIndex: number = this.getNextIndex();
         if (nextIndex < this.segments.length) {
             this.segmentIndex = nextIndex;
             const segment: ConversationSegment | null = this.segments[this.segmentIndex];
-            if (performAction && segment?.action) {
-                segment.action();
-            }
             return segment;
         }
         return null;
@@ -152,7 +156,7 @@ export class Conversation {
         return null;
     }
 
-    setDialogueState(state: string): number {
+    setDialogueState(state: string): ConversationSegment | null {
         if (!state) {
             // Assume we want the conversation to end
             this.segmentIndex = this.segments.length;
@@ -161,11 +165,11 @@ export class Conversation {
         if (index < this.segments.length) {
             this.segmentIndex = index;
             console.log(`Set dialogue state to "${state}" (${index})`);
-            return this.segmentIndex;
+            return this.segments[this.segmentIndex];
         }
         console.error('Unknown next dialogue state: "' + state + '"');
         this.segmentIndex = this.segments.length;
-        return this.segmentIndex;
+        return null;
     }
 
     /**

--- a/src/app/dw/ConversationSegment.spec.ts
+++ b/src/app/dw/ConversationSegment.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DwGame } from '@/app/dw/DwGame';
+import { Conversation } from '@/app/dw/Conversation';
+import { ConversationSegment } from '@/app/dw/ConversationSegment';
+
+describe('ConversationSegment', () => {
+    let game: DwGame;
+    let conversation: Conversation;
+
+    beforeEach(() => {
+        game = new DwGame();
+        conversation = new Conversation(game, false);
+    });
+
+    describe('currentText()', () => {
+        it('returns undefined for undefined', () => {
+            const segment = new ConversationSegment(conversation, game, {});
+            expect(segment.currentText()).toBeUndefined();
+        });
+
+        it('returns empty string for empty string', () => {
+            const segment = new ConversationSegment(conversation, game, { text: '' });
+            expect(segment.currentText()).toEqual('');
+        });
+
+        it('passes through plain text as-is', () => {
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'Hello world!',
+            });
+            expect(segment.currentText()).toEqual('Hello world!');
+        });
+
+        it('token replaces the hero name', () => {
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'Welcome, \\w{hero.name}.',
+            });
+            expect(segment.currentText()).toEqual('Welcome, Erdrick.');
+        });
+
+        it('token replaces the hero remaining experience', () => {
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'XP remaining to next level is \\w{hero.expRemaining}.',
+            });
+            expect(segment.currentText()).toEqual('XP remaining to next level is 12345.');
+        });
+
+        it('token replaces the item name', () => {
+            conversation.item = {
+                name: 'club',
+                baseCost: 10,
+                displayName: 'Club',
+            };
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'The item is a \\w{item.name}.',
+            });
+            expect(segment.currentText()).toEqual('The item is a Club.');
+        });
+
+        it('token replaces the item base cost', () => {
+            conversation.item = {
+                name: 'club',
+                baseCost: 10,
+                displayName: 'Club',
+            };
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'The item cost is \\w{item.baseCost} gold.',
+            });
+            expect(segment.currentText()).toEqual('The item cost is 10 gold.');
+        });
+
+        it('skips over unknown token replacements', () => {
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'This \\w{unknownToken} is not replaced.',
+            });
+            expect(segment.currentText()).toEqual('This \\w{unknownToken} is not replaced.');
+        });
+
+        it('replaces multiple tokens', () => {
+            conversation.item = {
+                name: 'club',
+                baseCost: 10,
+                displayName: 'Club',
+            };
+            const segment = new ConversationSegment(conversation, game, {
+                text: 'The \\w{item.name} costs \\w{item.baseCost} gold.',
+            });
+            expect(segment.currentText()).toEqual('The Club costs 10 gold.');
+        });
+    });
+});

--- a/src/app/dw/ConversationSegment.ts
+++ b/src/app/dw/ConversationSegment.ts
@@ -16,33 +16,120 @@ export interface ConversationSegmentArgsChoiceWithNextStep {
     next: string | (() => string);
 }
 
+// TODO: This might be better defined as a discriminated union due to conversationType?
 /**
- * For NPC chats more complex than static strings, this interface represents
- * the data that defines all possibilities.
+ * For NPC chats more complex than static strings, this interface represents the data that defines all
+ * possibilities. The best way to familiarize yourself with the structure is to look at the map data
+ * in src/app/dw/mapLogic/.
  */
 export interface ConversationSegmentArgs {
+    /**
+     * If defined, this callback is executed immediately when the segment first starts.
+     */
     action?: () => void;
+
+    /**
+     * If defined, this callback is executed when the segment ends.
+     */
+    afterAction?: () => ConversationSegmentArgs[] | undefined;
+
+    /**
+     * If defined, an amount of time that is waited before automatically advancing to the next segment (not requiring
+     * the player to press a button). This is often used with conversations representing actions such as battles, where
+     * it can be used with "afterSound" to delay for the length of a sound effect, or slightly longer, as desired.
+     */
+    afterAutoAdvanceDelay?: number;
+
+    /**
+     * If defined, this sound effect is played after the segment finishes.
+     */
     afterSound?: string;/*SoundEffect*/
+
+    /**
+     * A list of choices the hero can make in this segment. The choice list is displayed after the "text" is
+     * displayed. This is used both when conversationType == "merchant" and in conversations when the hero can
+     * make a choice (e.g. Yes/No => "But thou must!").
+     */
     choices?: ConversationSegmentArgsChoice[];
+
+    /**
+     * If true, this segment will clear all prior text before rendering.
+     */
     clear?: boolean;
+
+    /**
+     * If defined, this is a special "templated' conversation for a specific NPC type/situation.
+     * In this case, only specific fields in this object are used. See the implementation for details.
+     * "merchant" requires "choices" and optionally takes "introText".
+     * "innkeeper" requires "cost".
+     */
     conversationType?: 'merchant' | 'innkeeper';
+
+    /**
+     * Currently only used if conversationType == 'innkeeper'.
+     */
     cost?: number;
+
+    /**
+     * The ID of this segment. Only needs to be defined if it needs to be referenced elsewhere, such as by another
+     * segment's "next" field.
+     */
     id?: string;
+
+    /**
+     * Currently only used if conversationType == 'merchant'. This is their greeting to the hero when they
+     * first arrive at the shop. If undefined, a default is used.
+     */
     introText?: string;
+
+    /**
+     * If defined, this music is played immediately when this segment starts.
+     */
     music?: string;
+
+    /**
+     * If defined, the conversation should jump to this segment (by "id") next. If undefined, the next
+     * segment in the conversation's array is used. See also Conversation.DONE.
+     */
     next?: string;
+
+    /**
+     * Currently only used in when conversationType == 'innkeeper'. If true, after the segment finishes,
+     * the game plays the overnight jingle and fades out, then back in, simulating staying overnight.
+     */
     overnight?: boolean;
+
+    /**
+     * If defined, after this segment's text completes, the hero is shown a shopping bubble with the
+     * items specified to choose from. This is currently used when conversationType == 'merchant'.
+     */
     shopping?: ShoppingInfo;
+
+    /**
+     * If defined, this sound is played immediately when this segment starts.
+     */
     sound?: string;/*SoundEffect*/
+
+    /**
+     * The text content of this segment. This should always be defined unless the conversationType is
+     * defined to make this a template.
+     */
     text?: string;
 }
 
+/**
+ * A part of a conversation between the hero and an NPC, or between two NPCs. At its core, it represents some
+ * text that the user must press an action key to advance past, but it also includes a lot of configurability -
+ * tie sound effects to the text, add logic to run before or after the text renders, etc.
+ */
 export class ConversationSegment implements ConversationSegmentArgs {
 
     private readonly game: DwGame;
     parentConversation: Conversation;
 
     action?: () => void;
+    afterAction?: () => ConversationSegmentArgs[] | undefined;
+    afterAutoAdvanceDelay?: number;
     afterSound?: string;/*SoundEffect*/
     choices?: ConversationSegmentArgsChoice[];
     clear?: boolean;

--- a/src/app/dw/DwGame.ts
+++ b/src/app/dw/DwGame.ts
@@ -63,7 +63,7 @@ export class DwGame extends Game {
     private cameraDx = 0;
     private cameraDy = 0;
 
-    constructor(args: GameArgs) {
+    constructor(args?: GameArgs) {
         super(args);
 
         // Create and initialize party

--- a/src/app/dw/Item.spec.ts
+++ b/src/app/dw/Item.spec.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getItemByName, HERB, KEY, TORCH } from '@/app/dw/Item';
+import { RoamingState } from '@/app/dw/RoamingState';
+import { DwGame } from '@/app/dw/DwGame';
+import { DwMap } from '@/app/dw/DwMap';
+
+const mockFont = {
+    cellW: 8,
+    cellH: 9,
+};
+
+const mockOverworldMap = {
+    npcs: [],
+    getProperty: () => null,
+};
+
+const mockCaveMap = {
+    npcs: [],
+    getProperty: () => true,
+};
+
+describe('Item', () => {
+    let roamingState: RoamingState;
+
+    beforeEach(() => {
+        const game = new DwGame();
+        game.assets.set('font', mockFont);
+        game.assets.set('overworld', mockOverworldMap);
+        game.maps.overworld = mockOverworldMap as unknown as DwMap;
+        game.assets.set('cave', mockCaveMap);
+        game.maps.cave = mockCaveMap as unknown as DwMap;
+        roamingState = new RoamingState(game);
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('toString() works', () => {
+        expect(HERB.toString()).toEqual('[Item: name=Herb]');
+    });
+
+    describe('Herb', () => {
+        it('costs 24 gold', () => {
+            expect(HERB.baseCost).toEqual(24);
+        });
+
+        it('use() works', () => {
+            const spy = vi.spyOn(roamingState, 'showOneLineConversation').mockImplementation(() => {});
+            const incHpSpy = vi.spyOn(roamingState.game.hero, 'incHp').mockImplementation(() => true);
+            expect(HERB.use(roamingState)).toEqual(true);
+            expect(spy).toHaveBeenCalledExactlyOnceWith(false, '\\w{hero.name} used the Herb.');
+            expect(incHpSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('Key', () => {
+        it('costs 53 gold', () => {
+            expect(KEY.baseCost).toEqual(53);
+        });
+
+        it('use() works', () => {
+            const spy = vi.spyOn(roamingState, 'openDoor').mockImplementation(() => true);
+            expect(KEY.use(roamingState)).toEqual(true);
+            expect(spy).toHaveBeenCalledExactlyOnceWith();
+        });
+    });
+
+    describe('Torch', () => {
+        it('costs 8 gold', () => {
+            expect(TORCH.baseCost).toEqual(8);
+        });
+
+        describe('use()', () => {
+            describe('when the map does not require a torch', () => {
+                beforeEach(() => {
+                    roamingState.game.setMap('overworld');
+                });
+
+                it('works', () => {
+                    const spy = vi.spyOn(roamingState, 'showOneLineConversation').mockImplementation(() => {});
+                    expect(TORCH.use(roamingState)).toEqual(false);
+                    expect(spy).toHaveBeenCalledExactlyOnceWith(false, 'A torch can be used only in dark places.');
+                });
+            });
+
+            describe('when the map does require a torch', () => {
+                beforeEach(() => {
+                    roamingState.game.setMap('cave');
+                });
+
+                it('works', () => {
+                    const spy = vi.spyOn(roamingState, 'showOneLineConversation').mockImplementation(() => {});
+                    const setUsingTorchSpy = vi.spyOn(roamingState.game, 'setUsingTorch');
+                    expect(TORCH.use(roamingState)).toEqual(true);
+                    expect(spy).not.toHaveBeenCalled();
+                    expect(setUsingTorchSpy).toHaveBeenCalledExactlyOnceWith(true);
+                });
+            });
+        });
+    });
+
+    describe('getItemByName()', () => {
+        it('works', () => {
+            expect(getItemByName('Herb')).toEqual(HERB);
+            expect(getItemByName('Magic Key')).toEqual(KEY);
+            expect(getItemByName('Torch')).toEqual(TORCH);
+        });
+
+        it('returns undefined for unknown items', () => {
+            expect(getItemByName('unknown')).toBeUndefined();
+        });
+    });
+});

--- a/src/app/dw/Item.ts
+++ b/src/app/dw/Item.ts
@@ -38,7 +38,7 @@ export const HERB: Item = new Item('Herb', {
     baseCost: 24,
     use: (state: RoamingState) => {
         const hpRecovered = Utils.randomInt(23, 31);
-        state.showOneLineConversation(true, '\\w{hero.name} used the Herb.');
+        state.showOneLineConversation(false, '\\w{hero.name} used the Herb.');
         state.game.hero.incHp(hpRecovered);
         return true;
     },
@@ -57,7 +57,7 @@ export const TORCH: Item = new Item('Torch', {
         if (state.game.getMap().getProperty('requiresTorch', false)) {
             return state.game.setUsingTorch(true);
         }
-        state.showOneLineConversation(true, 'A torch can be used only in dark places.');
+        state.showOneLineConversation(false, 'A torch can be used only in dark places.');
         return false;
     },
 });

--- a/src/app/dw/PartyMember.ts
+++ b/src/app/dw/PartyMember.ts
@@ -7,6 +7,7 @@ import { Weapon } from './Weapon';
 import { Armor } from './Armor';
 import { Enemy } from './Enemy';
 import { DwGame } from './DwGame';
+import { healSpell, hurtSpell, Spell } from '@/app/dw/Spell';
 
 export interface PartyMemberArgs extends RoamingEntityArgs {
     hp?: number;
@@ -28,7 +29,7 @@ export class PartyMember extends RoamingEntity {
     weapon?: Weapon;
     armor?: Armor;
     shield?: Shield;
-    readonly spells: string[]; // TODO
+    readonly spells: Spell[];
 
     constructor(game: DwGame, args: PartyMemberArgs) {
 
@@ -45,7 +46,7 @@ export class PartyMember extends RoamingEntity {
         this.mp = args.mp ?? args.maxMp ?? 0;
         this.maxMp = this.mp;
 
-        this.spells = [];
+        this.spells = [ healSpell, hurtSpell ];
 
         //BattleEntity.call(this, args); // TODO: Better way to do a mixin?
         //Utils.mixin(RoamingEntityMixin.prototype, this);

--- a/src/app/dw/Spell.spec.ts
+++ b/src/app/dw/Spell.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { healSpell, hurtSpell } from '@/app/dw/Spell';
+import { Enemy } from '@/app/dw/Enemy';
+import { DwGame } from '@/app/dw/DwGame';
+import { Hero } from '@/app/dw/Hero';
+
+describe('Spell', () => {
+    let game: DwGame;
+
+    beforeEach(() => {
+        game = new DwGame();
+        game.assets.set('enemies', {
+            slime: {
+                name: 'Slime',
+                image: 'Slime',
+                damagedImage: 'Slime_damaged',
+                str: 5,
+                agility: 3,
+                hp: 3,
+                resist: { sleep: 0, stopSpell: 15, hurt: 0 },
+                dodge: 1,
+                xp: 1,
+                gp: 1,
+                ai: 'attackOnly',
+            },
+        });
+    });
+
+    describe('healSpell', () => {
+        it('costs 4 mp', () => {
+            expect(healSpell.cost).toEqual(4);
+        });
+
+        describe('when the caster is an Enemy', () => {
+            let caster: Enemy;
+
+            beforeEach(() => {
+                caster = new Enemy(game, game.getEnemy('slime'));
+            });
+
+            it('adds to their hp', () => {
+                caster.hp = 1;
+                healSpell.cast(caster);
+                expect(caster.hp).toBeGreaterThan(1);
+            });
+
+            it('honors their max HP', () => {
+                caster.hp = caster.maxHp - 1;
+                healSpell.cast(caster);
+                expect(caster.hp).toEqual(caster.maxHp);
+            });
+
+            it('returns the expected response', () => {
+                expect(healSpell.cast(caster)).toEqual({});
+            });
+        });
+
+        describe('when the caster is a Hero', () => {
+            let caster: Hero;
+
+            beforeEach(() => {
+                caster = new Hero(game, { name: 'Erdrick' });
+            });
+
+            it('adds to their hp', () => {
+                caster.hp = 1;
+                healSpell.cast(caster);
+                expect(caster.hp).toBeGreaterThan(1);
+            });
+
+            it('honors their max HP', () => {
+                caster.hp = caster.maxHp - 1;
+                healSpell.cast(caster);
+                expect(caster.hp).toEqual(caster.maxHp);
+            });
+
+            it('returns the expected response', () => {
+                expect(healSpell.cast(caster)).toEqual({});
+            });
+        });
+    });
+
+    describe('hurtSpell', () => {
+        let hero: Hero;
+        let enemy: Enemy;
+
+        beforeEach(() => {
+            hero = new Hero(game, { name: 'Erdrick' });
+            enemy = new Enemy(game, game.getEnemy('slime'));
+        });
+
+        it('costs 2 mp', () => {
+            expect(hurtSpell.cost).toEqual(2);
+        });
+
+        describe('when the caster is an Enemy', () => {
+            it('lowers the target\'s hp', () => {
+                hero.hp = hero.maxHp;
+                hurtSpell.cast(enemy, hero);
+                expect(hero.hp).toBeLessThan(hero.maxHp);
+            });
+
+            it('does not take the target\'s HP below 0', () => {
+                hero.hp = 1;
+                hurtSpell.cast(enemy, hero);
+                expect(hero.hp).toEqual(0);
+            });
+
+            it('returns the expected response', () => {
+                const result = hurtSpell.cast(enemy, hero);
+                expect(result.conversationSegments).toBeDefined();
+                expect(result.conversationSegments?.length).toEqual(1);
+                expect(result.conversationSegments?.[0].text).toMatch(/Thy Hit Points have been reduced by \d+./);
+            });
+        });
+
+        describe('when the caster is a Hero', () => {
+            it('lowers the target\'s hp', () => {
+                enemy.hp = enemy.maxHp;
+                hurtSpell.cast(hero, enemy);
+                expect(enemy.hp).toBeLessThan(enemy.maxHp);
+            });
+
+            it('does not take the target\'s HP below 0', () => {
+                hero.hp = 1;
+                hurtSpell.cast(hero, enemy);
+                expect(enemy.hp).toEqual(0);
+            });
+
+            it('returns the expected response', () => {
+                const result = hurtSpell.cast(hero, enemy);
+                expect(result.conversationSegments).toBeDefined();
+                expect(result.conversationSegments?.length).toEqual(1);
+                expect(result.conversationSegments?.[0].text).toMatch(
+                    /The Slime's Hit Points have been reduced by \d+./);
+            });
+
+            it('returns the expected response when there is no target', () => {
+                const result = hurtSpell.cast(hero);
+                expect(result.conversationSegments).toBeDefined();
+                expect(result.conversationSegments?.length).toEqual(1);
+                expect(result.conversationSegments?.[0].text).toEqual('But nothing happened.');
+            });
+        });
+    });
+});

--- a/src/app/dw/Spell.ts
+++ b/src/app/dw/Spell.ts
@@ -1,0 +1,73 @@
+import { Utils } from 'gtp';
+import { Hero } from '@/app/dw/Hero';
+import { Enemy } from '@/app/dw/Enemy';
+import { ConversationSegmentArgs } from '@/app/dw/ConversationSegment';
+
+export type SpellTarget = Hero | Enemy;
+
+export interface SpellResult {
+    conversationSegments?: ConversationSegmentArgs[] | undefined;
+}
+
+export interface Spell {
+    name: string;
+    cost: number;
+    cast(caster: SpellTarget, target?: SpellTarget): SpellResult;
+}
+
+const healSpell: Spell = {
+    name: 'HEAL',
+    cost: 4,
+    cast(caster: SpellTarget, target?: SpellTarget): SpellResult {
+        const healAmount = Utils.randomInt(10, 18);
+        caster.hp = Math.min(caster.hp + healAmount, caster.maxHp);
+        return {};
+    },
+};
+
+const hurtSpell: Spell = {
+    name: 'HURT',
+    cost: 2,
+    cast(caster: SpellTarget, target?: SpellTarget): SpellResult {
+        // Player casts Hurt outside of battle
+        if (!target) {
+            return {
+                conversationSegments: [
+                    {
+                        text: 'But nothing happened.',
+                    },
+                ],
+            };
+        }
+
+        let damage = 0;
+        let targetDescription = 'Thy';
+        if (target instanceof Hero) {
+            let min: number;
+            let max: number;
+
+            if (target.armor?.name === 'magicArmor' || target.armor?.name === 'erdricksArmor') {
+                min = 2;
+                max = 6;
+            } else {
+                min = 3;
+                max = 10;
+            }
+            damage = Utils.randomInt(min, max + 1);
+        } else {
+            damage = Utils.randomInt(5, 13);
+            targetDescription = `The ${target.name}'s`;
+        }
+        target.takeDamage(damage);
+
+        return {
+            conversationSegments: [
+                {
+                    text: `${targetDescription} Hit Points have been reduced by ${damage}.`,
+                },
+            ],
+        };
+    },
+};
+
+export { healSpell, hurtSpell };

--- a/src/app/dw/SpellBubble.spec.ts
+++ b/src/app/dw/SpellBubble.spec.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SpellBubble } from '@/app/dw/SpellBubble';
+import { healSpell } from '@/app/dw/Spell';
+import { DwGame } from '@/app/dw/DwGame';
+
+const mockFont = {
+    cellW: 8,
+    cellH: 9,
+};
+
+describe('SpellBubble', () => {
+    let game: DwGame;
+
+    beforeEach(() => {
+        game = new DwGame();
+        game.assets.set('font', mockFont);
+    });
+
+    it('initializes properly', () => {
+        const bubble = new SpellBubble(game);
+        expect(bubble.getSelectedIndex()).toEqual(0);
+        expect(bubble.getSelectedItem()).toEqual(healSpell);
+    });
+});

--- a/src/app/dw/SpellBubble.ts
+++ b/src/app/dw/SpellBubble.ts
@@ -1,0 +1,20 @@
+import { DwGame } from './DwGame';
+import { ChoiceBubble } from '@/app/dw/ChoiceBubble';
+import { Spell } from '@/app/dw/Spell';
+
+export class SpellBubble extends ChoiceBubble<Spell> {
+
+    constructor(game: DwGame) {
+
+        const tileSize: number = game.getTileSize();
+        const x: number = 9 * tileSize;
+        const y: number = 2 * tileSize;
+
+        const inventorySize = game.hero.spells.length;
+        const w: number = 7 * tileSize;
+        const h: number = (inventorySize + 2) * tileSize;
+
+        const spells = game.hero.spells;
+        super(game, x, y, w, h, spells, (choice) => choice.name, true, 'SPELL');
+    }
+}

--- a/src/app/dw/TextBubble.spec.ts
+++ b/src/app/dw/TextBubble.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DwGame } from '@/app/dw/DwGame';
+import { TextBubble } from '@/app/dw/TextBubble';
+import { Conversation } from '@/app/dw/Conversation';
+
+const mockFont = {
+    cellW: 8,
+    cellH: 9,
+};
+
+describe('TextBubble', () => {
+    let game: DwGame;
+    let bubble: TextBubble;
+
+    beforeEach(() => {
+        game = new DwGame();
+        game.assets.set('font', mockFont);
+        bubble = new TextBubble(game);
+    });
+
+    describe('when no text has been added', () => {
+        it('is done', () => {
+            expect(bubble.isDone()).toEqual(true);
+        });
+    });
+
+    describe('setConversation()', () => {
+        const content = 'Hello world!';
+
+        beforeEach(() => {
+            const conversation = new Conversation(game);
+            conversation.addSegment(content);
+            bubble.setConversation(conversation);
+        });
+
+        it('is not considered done', () => {
+            expect(bubble.isDone()).toEqual(false);
+        });
+
+        describe('when a button is pressed', () => {
+            describe('and there is no additional segments of content', () => {
+                beforeEach(() => {
+                    vi.spyOn(game, 'anyKeyDown').mockReturnValue(true);
+                    bubble.handleInput();
+                });
+
+                it('is considered done', () => {
+                    expect(bubble.isDone()).toEqual(true);
+                });
+
+                it('returns true after the next handleInput() to denote the conversation is done', () => {
+                    expect(bubble.handleInput()).toEqual(true);
+                });
+            });
+
+            describe('and there are no additional segments of content', () => {
+                beforeEach(() => {
+                    bubble.addToConversation('Second line');
+                    vi.spyOn(game, 'anyKeyDown').mockReturnValue(true);
+                    bubble.handleInput();
+                });
+
+                it('is not considered done', () => {
+                    expect(bubble.isDone()).toEqual(false);
+                });
+
+                it('returns true after the next handleInput() to denote the conversation is done', () => {
+                    expect(bubble.handleInput()).toEqual(false);
+                });
+            });
+        });
+    });
+});

--- a/src/app/dw/mapLogic/AbstractMapLogic.ts
+++ b/src/app/dw/mapLogic/AbstractMapLogic.ts
@@ -2,7 +2,7 @@ import { DwGame } from '../DwGame';
 import { Npc } from '../Npc';
 import { MapLogic, NpcText } from './MapLogic';
 
-export type NpcTextGenerator = (map: DwGame) => NpcText;
+export type NpcTextGenerator = (game: DwGame) => NpcText;
 
 export type NpcTextGeneratorMap = Record<string, NpcTextGenerator>;
 


### PR DESCRIPTION
Fixes #34. Allow the hero to cast `HEAL` and `HURT` while roaming (not necessarily when in battle).

**A/C:**
- [x] Spells are available in menu
- [x] Spells do not cast when MP is too low
- [x] Bubble text and sound effects are correct
- [x] Bubble correctly auto-advances after the spell sound effect plays
- [x] `HEAL` heals the hero appropriately
- [x] `HURT` does nothing and displays the correct follow-up message to the player
- [x] Code is at least in a mildly reusable state to be used by enemies, and in battle
- [x] Unit tests for new/modified code