### PR TITLE
chore: add Claude Code configuration

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,34 @@
+# Create a Pull Request
+
+Create a branch (if needed), commit staged/unstaged changes, push, and open a PR.
+
+## Steps
+
+1. **Check branch status**: Run `git status` and `git branch --show-current`
+   - If on `master` or `main`, create a new branch:
+     - Analyze the changes to determine a descriptive branch name
+     - Use lower-kebab-case (e.g., `add-user-authentication`, `fix-login-bug`)
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue on that branch
+
+2. **Review changes**: Run `git status` and `git diff` to understand what will be committed
+
+3. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`)
+   - Write a commit message using the [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
+     - Don't read the conventional commit site/URL if you already know the style
+     - Use "!" after the type to indicate a breaking change
+     - Use "build(deps)" for dependency bumps
+     - Besides dependencies, don't worry too much about adding a scope to the commit type unless it's a larger
+       change concentrated on a specific component or area
+   - Do NOT run `npm run test` as this project doesn't yet have unit tests
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit
+
+4. **Push**: Run `git push -u origin <branch-name>`
+
+5. **Create PR**: Use `gh pr create` with:
+   - A concise title matching the commit style
+   - A body with `## Summary` (bullet points) and `## Test plan` sections
+   - Footer: `🤖 Generated with [Claude Code](https://claude.ai/claude-code)`
+
+If any step fails, report the error and ask how to proceed.

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ node_modules
 .tmp
 dist
 Thumbs.db
-
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This project is a clone of the original Dragon Warrior game on the NES. It tries to be as
+authentic to the source as possible, with just a couple of quality-of-life improvements.
+
+It's written in vanilla TypeScript, renders on `canvas` and is built with vite.
+
+## Project Structure
+
+- `src/` - Game source code
+- `src/app/dw/mapLogic` - Classes representing the "logic" of every map in the game.
+- `public/res/` - Static assets (graphics, sounds, etc.)
+- `updater-lambda/` - Node.js AWS Lambda that scrapes Yahoo Finance and generates JSON data
+
+## Common Commands
+
+### Frontend (run from `app/` directory)
+
+```bash
+npm install                # Install dependencies
+npm run dev                # Start dev server
+npm run build              # Build to dist/
+npm run serve              # Build to dist/ and serve locally for testing prod build
+npm run test:unit          # Run unit tests with coverage (currently fails, no tests)
+npm run lint               # Lint without fixing (CI mode, fails on warnings)
+npm run lint:fix           # Lint and fix issues
+npm run test               # Runs unit tests
+npm run tsc                # Runs typecheck
+```
+
+## High-Level Architecture
+
+* The game uses an open-source library called [gtp](https://github.com/bobbylight/gtp) that
+  provides basic support for game states, resource loading, tilesets, audio, etc.
+* A top-level entry point is "state" classes. The game is always running a state -
+  `LoadingState`, `RoamingState`, `BattleState`, etc.
+* The player's game state is also (confusingly) stored in `DwGameState`. But this part of the
+  game isn't well fleshed out yet. Typically, "state" refers to the game state classes
+  mentioned in the prior point.
+* Being an old-school RPG, there are lots of text and menu bubbles. These are all implemented
+  as subclasses of a base `Bubble` class. See e.g. `TextBubble`, `SpellBubble` and others.
+* Map data is created in Tiled(https://www.mapeditor.org/) and exported as JSON. The map data
+  is in `public/res/maps/`. Each map contains layers for NPCs, warps, collisions, and enemy
+  spawns.
+* Each map has a corresponding "map logic" file that lives in `src/app/dw/mapLogic`. These
+  logic files define the NPC text on the map as well as any other special events.
+
+## Submitting PRs
+
+- Use conventional commit syntax (feat:, fix:, chore:, docs:, refactor:, test:, etc.)
+- Ensure tests pass before committing and fix anything if necessary. If any tests
+  needed fixing, let me review the changes before proceeding with the commit.`
+- Commit messages don't need to mention tests being added. Only mention tests when a
+  large amount of tests were added for previously uncovered code, or there was a
+  major refactoring of test code.
+- Always amend the current commit if the current PR is still in draft.
+


### PR DESCRIPTION
Add scaffolding for Claude Code, so we can see how well it helps in old-school 2D game clones like this one.

## Summary

- Add `CLAUDE.md` with project overview, directory structure, common commands, and high-level architecture notes for Claude Code
- Add `.claude/commands/pr.md` as a custom `/pr` skill for streamlined PR creation
- Ignore `.claude/settings.local.json` to keep local Claude settings out of version control

## Test plan

- [x] Verify `CLAUDE.md` is picked up by Claude Code in this repo
- [x] Verify `/pr` skill works as expected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)