### PR TITLE
refactor: discriminated union for EnemyAiResult

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -37,8 +37,7 @@ Create a branch (if needed), commit staged/unstaged changes, push, and open/upda
 
 6. **Create or update PR**:
    - Check if a PR already exists for this branch with `gh pr view`
-   - If no PR exists: use `gh pr create` with the title, body, and labels below
-     - When creating a new PR, create it as a draft
+   - If no PR exists: use `gh pr create --draft` with the title, body, and labels below
    - If a PR exists: use `gh pr edit` to update the title, body, and labels
    - Title: concise, matching the commit style
    - Body: formatted using this repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`),

--- a/src/app/dw/BattleState.ts
+++ b/src/app/dw/BattleState.ts
@@ -94,26 +94,31 @@ Thy gold increases by ${this.enemy.gp}.`;
 
         const result: EnemyAiResult = this.enemy.ai(this.game.hero, this.enemy);
 
-        if (result.type === 'physical') {
-            const text = `The ${this.enemy.name} attacks!`;
-            this.textBubble.addToConversation({ text,
-                afterSound: 'prepareToAttack' }, true);
-            this.textBubble.onDone(() => {
-                this.enemyAttackDelay = new Delay({
-                    millis: 350,
-                    callback: this.enemyAttackCallback.bind(this),
+        switch (result.type) {
+            case 'physical': {
+                const text = `The ${this.enemy.name} attacks!`;
+                this.textBubble.addToConversation({ text,
+                    afterSound: 'prepareToAttack' }, true);
+                this.textBubble.onDone(() => {
+                    this.enemyAttackDelay = new Delay({
+                        millis: 350,
+                        callback: this.enemyAttackCallback.bind(this),
+                    });
                 });
-            });
-        } else { // 'magic'
-            const text = `The ${this.enemy.name} chants the spell of ${result.spellName}.`;
-            // TODO: Should conversations auto-wait for afterSounds to complete?
-            this.textBubble.addToConversation({ text, afterSound: 'castSpell' }, true);
-            this.textBubble.onDone(() => {
-                this.enemyAttackDelay = new Delay({
-                    millis: 900,
-                    callback: this.enemyAttackCallback.bind(this),
+                break;
+            }
+            case 'magic': {
+                const text = `The ${this.enemy.name} chants the spell of ${result.spellName}.`;
+                // TODO: Should conversations auto-wait for afterSounds to complete?
+                this.textBubble.addToConversation({ text, afterSound: 'castSpell' }, true);
+                this.textBubble.onDone(() => {
+                    this.enemyAttackDelay = new Delay({
+                        millis: 900,
+                        callback: this.enemyAttackCallback.bind(this),
+                    });
                 });
-            });
+                break;
+            }
         }
     }
 

--- a/src/app/dw/EnemyAI.ts
+++ b/src/app/dw/EnemyAI.ts
@@ -16,11 +16,9 @@ aiMap.halfHurtHalfAttack = (hero: Hero, enemy: Enemy) => {
     return { type: 'physical', damage: enemy.computePhysicalAttackDamage(hero) };
 };
 
-export interface EnemyAiResult {
-   type: string;
-   damage: number;
-   spellName?: string;
-}
+export type EnemyAiResult =
+    | { type: 'physical'; damage: number }
+    | { type: 'magic'; spellName: string; damage: number };
 
 export type EnemyAiFunc = (hero: Hero, enemy: Enemy) => EnemyAiResult;
 


### PR DESCRIPTION
## Summary

Replaces the `EnemyAiResult` interface (which had an optional `spellName` field only meaningful for magic attacks) with a proper discriminated union.

## Details

- `EnemyAiResult` is now `{ type: 'physical'; damage: number } | { type: 'magic'; spellName: string; damage: number }`
- `spellName` is required (not optional) on the `'magic'` variant — impossible to omit it
- A physical result can no longer accidentally carry a `spellName`
- `BattleState.enemyAttack()` updated to use a `switch` so TypeScript narrows each case cleanly without casts or comments

## Test plan

- [x] Fight an enemy that only uses physical attacks and verify the battle flow
- [x] Fight a Magician (or similar) that casts Hurt and verify the spell name appears correctly in the text bubble

🤖 Generated with [Claude Code](https://claude.ai/claude-code)