### PR TITLE
refactor: replace NpcType class with a string literal union

### DIFF
--- a/src/app/dw/Npc.ts
+++ b/src/app/dw/Npc.ts
@@ -2,7 +2,7 @@ import { Delay, SpriteSheet, Utils } from 'gtp';
 import { RoamingEntity, RoamingEntityArgs } from './RoamingEntity';
 import { Direction } from './Direction';
 import { Hero } from './Hero';
-import { NpcType } from './NpcType';
+import { NpcType, getNpcSpriteRow } from './NpcType';
 import { DwGame } from './DwGame';
 
 type DirFunctionType = () => void;
@@ -25,7 +25,7 @@ export class Npc extends RoamingEntity {
 
     constructor(game: DwGame, args: NpcArgs) {
         super(game, args);
-        this.type = args.type ?? NpcType.MERCHANT_GREEN;
+        this.type = args.type ?? 'MERCHANT_GREEN';
         this.wanders = args.wanders;
 
         this.origMapRow = this.mapRow;
@@ -71,7 +71,7 @@ export class Npc extends RoamingEntity {
     render(ctx: CanvasRenderingContext2D) {
 
         const ss: SpriteSheet = this.game.assets.get('npcs');
-        const ssRow: number = this.type as number;
+        const ssRow: number = getNpcSpriteRow(this.type);
         let ssCol: number = this.computeColumn();
         let x: number = this.mapCol * this.game.getTileSize();
         x -= this.game.getMapXOffs();

--- a/src/app/dw/NpcType.ts
+++ b/src/app/dw/NpcType.ts
@@ -1,32 +1,40 @@
-// TODO: Convert this to a union type or some simpler struct
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class NpcType {
-    static readonly SOLDIER_GRAY: number = 0;
-    static readonly SOLDIER_RED: number = 1;
-    static readonly MAN_BLUE: number = 2;
-    static readonly WOMAN_BLUE: number = 3;
-    static readonly MERCHANT_GREEN: number = 4;
-    static readonly OLD_MAN_GRAY: number = 5;
-    static readonly KING: number = 6;
-}
+/**
+ * The types of NPCs defined in the game's Tiled map files.
+ */
+export type NpcType =
+    | 'SOLDIER_GRAY'
+    | 'SOLDIER_RED'
+    | 'MAN_BLUE'
+    | 'WOMAN_BLUE'
+    | 'MERCHANT_GREEN'
+    | 'OLD_MAN_GRAY'
+    | 'KING';
 
+/**
+ * A mapping of NPC type to the row in the sprite sheet containing their graphics.
+ */
+const npcSpriteRows: Record<NpcType, number> = {
+    SOLDIER_GRAY: 0,
+    SOLDIER_RED: 1,
+    MAN_BLUE: 2,
+    WOMAN_BLUE: 3,
+    MERCHANT_GREEN: 4,
+    OLD_MAN_GRAY: 5,
+    KING: 6,
+};
+
+/**
+ * Returns the row in the NPC sprite sheet containing an NPC type's graphics.
+ */
+export const getNpcSpriteRow = (type: NpcType): number => npcSpriteRows[type];
+
+const npcTypeSet = new Set<string>(Object.keys(npcSpriteRows));
+
+/**
+ * Returns the NPC type for a specified string. If this value is unknown, a default
+ * value is returned.
+ */
 export const getNpcType = (type: string): NpcType => {
-    switch (type.toUpperCase()) {
-        case 'SOLDIER_GRAY':
-            return 0;
-        case 'SOLDIER_RED':
-            return 1;
-        case 'MAN_BLUE':
-            return 2;
-        case 'WOMAN_BLUE':
-            return 3;
-        case 'MERCHANT_GREEN':
-            return 4;
-        case 'OLD_MAN_GRAY':
-            return 5;
-        case 'KING':
-            return 6;
-        default:
-            return NpcType.MERCHANT_GREEN;
-    }
+    const upper = type.toUpperCase();
+    return npcTypeSet.has(upper) ? upper as NpcType : 'MERCHANT_GREEN';
 };


### PR DESCRIPTION
## Summary

Replaces the `NpcType` static-constant class (numeric magic numbers + an `eslint-disable` to suppress the empty-class warning) with a string literal union and a `Record`-based sprite-row map.

## Details

- `NpcType` is now `'SOLDIER_GRAY' | 'SOLDIER_RED' | 'MAN_BLUE' | 'WOMAN_BLUE' | 'MERCHANT_GREEN' | 'OLD_MAN_GRAY' | 'KING'`
- `npcSpriteRows: Record<NpcType, number>` maps each type to its sprite sheet row — adding a new `NpcType` value without updating the record is a compile error
- `getNpcSpriteRow(type: NpcType): number` replaces the `this.type as number` cast in `Npc.render()`
- `getNpcType()` simplified from a `switch` to a set-membership check
- Removes the TODO comment, the `eslint-disable` for the extraneous class, and the `as number` cast
- Addresses the pre-existing TODO in the file

## Test plan

- [ ] Walk around a map with multiple NPC types and verify they all render with the correct sprites

🤖 Generated with [Claude Code](https://claude.ai/claude-code)