### PR TITLE
fix: enemy attacks after failed run attempt

### DIFF
--- a/src/app/dw/BattleState.spec.ts
+++ b/src/app/dw/BattleState.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { AudioSystem, Utils } from 'gtp';
+import { DwGame } from '@/app/dw/DwGame';
+import { BattleState } from '@/app/dw/BattleState';
+import { EnemyData } from '@/app/dw/Enemy';
+import { EnemyAiFunc } from '@/app/dw/EnemyAI';
+import { TextBubble } from '@/app/dw/TextBubble';
+
+const mockFont = {
+    cellW: 8,
+    cellH: 9,
+};
+
+const slimeData: EnemyData = {
+    name: 'Slime',
+    image: 'slime',
+    damagedImage: 'slimedamaged',
+    str: 3,
+    agility: 2,
+    hp: 3,
+    resist: {},
+    dodge: 0,
+    xp: 1,
+    gp: 1,
+    ai: 'attackOnly',
+};
+
+describe('BattleState', () => {
+    let game: DwGame;
+    let battleState: BattleState;
+    let playSoundSpy: MockInstance<AudioSystem['playSound']>;
+
+    beforeEach(() => {
+        game = new DwGame();
+        game.assets.set('font', mockFont);
+        game.assets.set('enemies', { slime: slimeData });
+        playSoundSpy = vi.spyOn(game.audio, 'playSound');
+        battleState = new BattleState(game, 'slime');
+        battleState.enter();
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    describe('run()', () => {
+        describe('when the run attempt fails', () => {
+            let enemyAiSpy: MockInstance<EnemyAiFunc>;
+            let addToConversationSpy: MockInstance<TextBubble['addToConversation']>;
+
+            beforeEach(() => {
+                // randomInt returns 0; runCallback treats 1 as success, 0 as failure
+                vi.spyOn(Utils, 'randomInt').mockReturnValue(0);
+
+                // Fire onDone callbacks immediately so the test doesn't depend on
+                // animation timing (the Bubble opening animation delays updateImpl).
+                const textBubble = battleState.getTextBubble();
+                vi.spyOn(textBubble, 'onDone').mockImplementation((cb: () => void) => {
+                    cb();
+                });
+
+                addToConversationSpy = vi.spyOn(textBubble, 'addToConversation');
+
+                // enemyAttack() is a private method, but we can tell it was called because the enemy's AI is run
+                enemyAiSpy = vi.spyOn(battleState.getEnemy(), 'ai').mockImplementation(() => {
+                    return {
+                        type: 'physical',
+                        damage: 3,
+                    };
+                });
+
+                battleState.run();
+                battleState.update(700); // advance past the 600ms run delay
+            });
+
+            it('prints that the hero runs away', () => {
+                expect(addToConversationSpy).toHaveBeenCalledWith(
+                    { text: 'Erdrick started to run away.' }, true,
+                );
+                expect(playSoundSpy).toHaveBeenCalledWith('run');
+            });
+
+            it('plays the run sound effect', () => {
+                expect(playSoundSpy).toHaveBeenCalledWith('run');
+            });
+
+            it('prints that the hero failed to run away', () => {
+                expect(addToConversationSpy).toHaveBeenCalledWith({ text: "Couldn't run!" });
+                expect(playSoundSpy).toHaveBeenCalledWith('run');
+            });
+
+            it('gives the enemy a turn to attack', () => {
+                expect(enemyAiSpy).toHaveBeenCalledOnce();
+            });
+        });
+    });
+});

--- a/src/app/dw/BattleState.ts
+++ b/src/app/dw/BattleState.ts
@@ -162,6 +162,14 @@ Thy gold increases by ${this.enemy.gp}.`;
         this.textBubble.setConversation(conversation);
     }
 
+    getEnemy(): Enemy {
+        return this.enemy;
+    }
+
+    getTextBubble(): TextBubble {
+        return this.textBubble;
+    }
+
     item() {
         this.textBubble.addToConversation({ text: 'Not implemented, command?' });
     }
@@ -236,10 +244,11 @@ Thy gold increases by ${this.enemy.gp}.`;
             this.commandExecuting = false;
             this.backToRoaming();
         } else {
-            this.commandExecuting = false;
             this.commandBubble.reset();
-            this.commandBubble.init();
             this.textBubble.addToConversation({ text: 'Couldn\'t run!' });
+            this.textBubble.onDone(() => {
+                this.enemyAttack();
+            });
         }
     }
 

--- a/src/app/dw/TextBubble.ts
+++ b/src/app/dw/TextBubble.ts
@@ -26,7 +26,7 @@ export class TextBubble extends Bubble {
     private choiceBubble?: ChoiceBubble<ConversationSegmentArgsChoice> | null;
     private shoppingBubble?: ShoppingBubble | null;
     private delay?: Delay;
-    private doneCallbacks: DoneCallback[];
+    private readonly doneCallbacks: DoneCallback[];
     private afterAutoAdvanceDelay: number;
     private inAutoAdvanceDelay: boolean;
     private afterSound: string | undefined;
@@ -327,10 +327,13 @@ export class TextBubble extends Bubble {
         }
 
         if (this.doneCallbacks.length > 0 && this.isDone()) {
-            this.doneCallbacks.forEach((callback: () => void) => {
-                callback();
-            });
-            this.doneCallbacks = [];
+            // Only run the callbacks that existed at the time the check was made.
+            // Done callbacks may add new done callbacks to run later.
+            const count = this.doneCallbacks.length;
+            for (let i = 0; i < count; i++) {
+                this.doneCallbacks[i]();
+            }
+            this.doneCallbacks.splice(0, count);
         }
 
     }


### PR DESCRIPTION
## Summary

When the player attempts to run away and fails, the enemy now correctly gets a turn to attack (previously they did not). Also fixes `TextBubble.onDone()` to safely support callbacks that register additional done-callbacks.

Fixes #82.

## Details

- **`BattleState.run()`**: After printing "Couldn't run!", register an `onDone` callback to trigger `enemyAttack()` rather than calling nothing. Previously the enemy skipped their turn entirely when a run failed.
- **`TextBubble.onDone()`**: Snapshot the callback list length before iterating so that newly-added callbacks (from within a callback) are not invoked in the same pass and are deferred to the next cycle.
- **`BattleState`**: Added `getEnemy()` and `getTextBubble()` getters to support unit testing of internal state.
- **`BattleState.spec.ts`**: New tests covering the failed-run scenario — verifies the "Couldn't run!" message is shown and the enemy AI is invoked.

## Video
![dwjs-run-fix](https://github.com/user-attachments/assets/8b3726c1-e7d7-48fd-a9c2-d562c38f5788)

## Test plan

- [x] Start a battle and attempt to run away multiple times until a failure occurs — confirm the enemy attacks after the failed run.
- [x] Verify unit tests pass: `npm run test`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)