### PR TITLE
refactor: simplify ShoppingBubble by extending ChoiceBubble

### DIFF
--- a/src/app/dw/ChoiceBubble.spec.ts
+++ b/src/app/dw/ChoiceBubble.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { InputManager } from 'gtp';
 import { DwGame } from '@/app/dw/DwGame';
 import { ChoiceBubble } from '@/app/dw/ChoiceBubble';
 
@@ -33,8 +34,8 @@ describe('ChoiceBubble', () => {
     describe('handleInput() - single column', () => {
 
         let bubble: ChoiceBubble<string>;
-        let upSpy: MockInstance;
-        let downSpy: MockInstance;
+        let upSpy: MockInstance<InputManager['up']>;
+        let downSpy: MockInstance<InputManager['down']>;
 
         beforeEach(() => {
             bubble = new ChoiceBubble(game, 0, 0, 100, 100, choices);
@@ -149,10 +150,10 @@ describe('ChoiceBubble', () => {
     describe('handleInput() - 2-column layout', () => {
 
         let bubble: ChoiceBubble<string>;
-        let upSpy: MockInstance;
-        let downSpy: MockInstance;
-        let leftSpy: MockInstance;
-        let rightSpy: MockInstance;
+        let upSpy: MockInstance<InputManager['up']>;
+        let downSpy: MockInstance<InputManager['down']>;
+        let leftSpy: MockInstance<InputManager['left']>;
+        let rightSpy: MockInstance<InputManager['right']>;
 
         beforeEach(() => {
             bubble = new ChoiceBubble(game, 0, 0, 200, 100, choices, undefined, false, undefined, 2);

--- a/src/app/dw/ChoiceBubble.ts
+++ b/src/app/dw/ChoiceBubble.ts
@@ -14,6 +14,7 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
     private curChoice: number;
     private readonly cancellable: boolean;
     private readonly columns: number;
+    protected yInc: number;
 
     constructor(game: DwGame, x: number, y: number, w: number, h: number,
         choices: ChoiceBubbleChoice[] = [],
@@ -27,6 +28,7 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
         this.cancellable = cancellable;
         this.columns = columns;
         this.curChoice = 0;
+        this.yInc = 18 * this.game.scale;
     }
 
     /**
@@ -102,7 +104,6 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
     override paintContent(ctx: CanvasRenderingContext2D, x: number, y: number) {
 
         ctx.fillStyle = 'rgb(255,255,255)';
-        const yInc = 18 * this.game.scale;
 
         if (this.columns === 2) {
             const leftCount = Math.ceil(this.choices.length / 2);
@@ -114,7 +115,7 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
                 const inRight = index >= leftCount;
                 const row = inRight ? index - leftCount : index;
                 const textX = inRight ? x + colWidth + colGap : x;
-                const textY = y + row * yInc;
+                const textY = y + row * this.yInc;
 
                 if (this.curChoice === index) {
                     const arrowX = inRight
@@ -130,7 +131,7 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
                     this.drawArrow(this.x + Bubble.ARROW_MARGIN, y);
                 }
                 this.game.drawString(this.choiceStringifier(choice), x, y);
-                y += yInc;
+                y += this.yInc;
             });
         }
     }

--- a/src/app/dw/ShoppingBubble.ts
+++ b/src/app/dw/ShoppingBubble.ts
@@ -1,71 +1,18 @@
-import { InputManager } from 'gtp';
-import { Bubble } from './Bubble';
 import { DwGame } from './DwGame';
 import { ShoppingInfo } from './ConversationSegment';
 import { Sellable } from './Sellable';
+import { ChoiceBubble } from './ChoiceBubble';
 
-export class ShoppingBubble extends Bubble {
-
-    private choices: Sellable[];
-    private curChoice: number;
+export class ShoppingBubble extends ChoiceBubble<Sellable> {
 
     constructor(game: DwGame, shoppingInfo: ShoppingInfo) {
 
         const tileSize: number = game.getTileSize();
-        const x: number = 5 * tileSize;
-        const y: number = 1 * tileSize;
-        const width: number = 9 * tileSize;
-        const height: number = 6 * tileSize;
-        super(game, undefined, x, y, width, height);
-
-        this.choices = shoppingInfo.choices.map((choice) => {
+        const choices = shoppingInfo.choices.map((choice) => {
             return game.getWeapon(choice) || game.getArmor(choice) || game.getShield(choice);
         });
-
-        this.curChoice = 0;
-    }
-
-    /**
-    * Returns whether the user is "done" talking; that is, whether the entire
-    * conversation has been rendered (including multiple pages, if necessary).
-    */
-    handleInput(): boolean {
-
-        const im: InputManager = this.game.inputManager;
-
-        if (this.game.cancelKeyPressed()) {
-            this.curChoice = -1;
-            return true;
-        } else if (this.game.actionKeyPressed()) {
-            return true;
-        } else if (im.up(true)) {
-            this.curChoice = Math.max(0, this.curChoice - 1);
-        } else if (im.down(true)) {
-            this.curChoice = Math.min(this.curChoice + 1, this.choices.length - 1);
-        }
-
-        return false;
-    }
-
-    override paintContent(ctx: CanvasRenderingContext2D, x: number, y: number) {
-
-        ctx.fillStyle = 'rgb(255,255,255)';
-        this.choices.forEach((choice, index) => {
-            if (this.curChoice === index) {
-                this.drawArrow(this.x + Bubble.ARROW_MARGIN, y);
-            }
-            this.game.drawString(choice.displayName, x, y);
-            y += 10 * this.game.scale;
-        });
-
-    }
-
-    getSelectedItem(): Sellable | undefined {
-        return this.curChoice === -1 ? undefined :
-            this.choices[this.curChoice];
-    }
-
-    setChoices(choices: Sellable[]) {
-        this.choices = choices;
+        super(game, 5 * tileSize, 1 * tileSize, 9 * tileSize, 6 * tileSize,
+            choices, (choice) => choice.displayName, true);
+        this.yInc = 10 * game.scale;
     }
 }


### PR DESCRIPTION
## Summary

`ShoppingBubble` previously duplicated logic already present in `ChoiceBubble` (input handling, selection state, painting). This refactor makes it extend `ChoiceBubble<Sellable>` directly, reducing it to a constructor-only class.

## Details

- `ShoppingBubble` now extends `ChoiceBubble<Sellable>` instead of `Bubble`
- Removed duplicate `handleInput()`, `paintContent()`, `getSelectedItem()`, and dead `setChoices()` method (~55 lines deleted)
- Added `protected yInc` field to `ChoiceBubble` (default `18 * scale`) so subclasses can override row spacing; `ShoppingBubble` sets it to `10 * scale`
- Fixes a pre-existing bug where navigating the shopping list didn't reset the arrow blink timer (now inherited from `ChoiceBubble`)

## Test plan

- [x] Open shop in-game, verify items display with correct spacing
- [x] Navigate up/down in shop list — arrow should immediately become visible on each keypress
- [x] Cancel and confirm selection both work as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)