### PR TITLE
feat: replace Weapon Change cheat with weapon select bubble

### DIFF
--- a/src/app/dw/Cheats.spec.ts
+++ b/src/app/dw/Cheats.spec.ts
@@ -3,11 +3,19 @@ import { DwGame } from '@/app/dw/DwGame';
 import { Cheats } from '@/app/dw/Cheats';
 import { EnemyData } from '@/app/dw/Enemy';
 import { ChoiceBubble } from '@/app/dw/ChoiceBubble';
+import { Weapon } from '@/app/dw/Weapon';
 
 const mockFont = {
     cellW: 8,
     cellH: 9,
 };
+
+const bambooStick = new Weapon('bambooStick', { name: 'bambooStick', displayName: 'Bamboo Stick', baseCost: 10, power: 2 });
+const club = new Weapon('club', { name: 'club', displayName: 'Club', baseCost: 60, power: 4 });
+const copperSword = new Weapon('copperSword', { name: 'copperSword', displayName: 'Copper Sword', baseCost: 180, power: 10 });
+
+// Intentionally out of power order to verify sorting
+const mockWeaponsArray: Weapon[] = [ club, bambooStick, copperSword ];
 
 const slimeData: EnemyData = {
     name: 'Slime',
@@ -68,10 +76,87 @@ describe('Cheats', () => {
         game = new DwGame();
         game.assets.set('font', mockFont);
         game.assets.set('enemies', mockEnemies);
+        game.assets.set('weaponsArray', mockWeaponsArray);
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    describe('createWeaponSelectBubble()', () => {
+
+        let bubble: ChoiceBubble<Weapon>;
+
+        beforeEach(() => {
+            bubble = Cheats.createWeaponSelectBubble(game);
+        });
+
+        it('has title "WEAPON"', () => {
+            expect(bubble.title).toEqual('WEAPON');
+        });
+
+        it('lists weapons sorted by power ascending', () => {
+            expect(bubble.getSelectedItem()).toEqual(bambooStick);
+        });
+
+        it('selects the first (weakest) weapon by default', () => {
+            expect(bubble.getSelectedIndex()).toEqual(0);
+        });
+
+        it('has width based on game width and tile size', () => {
+            expect(bubble.w).toEqual(game.getWidth() - 4 * game.getTileSize());
+        });
+
+        it('has height based on weapon count', () => {
+            expect(bubble.h).toEqual(mockWeaponsArray.length * 18 * game.scale + 1.5 * game.getTileSize());
+        });
+
+        it('uses the weapon displayName as the label', () => {
+            // The stringifier is tested indirectly by confirming the bubble renders the displayName.
+            // We verify the selected item is a Weapon with the correct displayName.
+            expect(bubble.getSelectedItem()?.displayName).toEqual('Bamboo Stick');
+        });
+
+        describe('when cancelled', () => {
+
+            it('marks input as handled and returns no selected item', () => {
+                vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(true);
+                vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'down').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+
+                const done = bubble.handleInput();
+
+                expect(done).toEqual(true);
+                expect(bubble.getSelectedItem()).toBeUndefined();
+                expect(bubble.getSelectedIndex()).toEqual(-1);
+            });
+        });
+
+        describe('when navigating down and confirming', () => {
+
+            it('selects the next weapon in ascending power order', () => {
+                vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+                vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'down').mockReturnValue(true);
+                vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+                vi.spyOn(game.audio, 'playSound').mockReturnValue(0);
+
+                bubble.handleInput(); // navigate down
+
+                vi.spyOn(game.inputManager, 'down').mockReturnValue(false);
+                vi.spyOn(game, 'actionKeyPressed').mockReturnValue(true);
+
+                const done = bubble.handleInput(); // confirm
+
+                expect(done).toEqual(true);
+                expect(bubble.getSelectedItem()).toEqual(club);
+            });
+        });
     });
 
     describe('createBattleBubble()', () => {

--- a/src/app/dw/Cheats.ts
+++ b/src/app/dw/Cheats.ts
@@ -2,6 +2,7 @@ import { Direction } from './Direction';
 import { DwGame } from './DwGame';
 import { ChoiceBubble } from './ChoiceBubble';
 import { EnemyData } from './Enemy';
+import { Weapon } from './Weapon';
 
 export type CheatOption =
     '9999 Gold' |
@@ -60,6 +61,19 @@ export class Cheats {
             (data) => data.shortName ?? data.name, true, 'BATTLE', 2);
         bubble.setYInc(lineHeight);
         return bubble;
+    }
+
+    static createWeaponSelectBubble(game: DwGame): ChoiceBubble<Weapon> {
+
+        const tileSize: number = game.getTileSize();
+        const weaponsArray: Weapon[] = game.assets.get('weaponsArray');
+        const weapons: Weapon[] = [ ...weaponsArray ].sort((a, b) => a.power - b.power);
+        const w: number = game.getWidth() - 4 * tileSize;
+        const h: number = weapons.length * 18 * game.scale + 1.5 * tileSize;
+        const x: number = (game.getWidth() - w) / 2;
+        const y: number = (game.getHeight() - h) / 2;
+
+        return new ChoiceBubble(game, x, y, w, h, weapons, (weapon) => weapon.displayName, true, 'WEAPON');
     }
 
     static createWarpBubble(game: DwGame): ChoiceBubble<WarpLocation> {

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -14,6 +14,7 @@ import { MapLogic } from './mapLogic/MapLogic';
 import { CheatOption, Cheats, WarpLocation } from './Cheats';
 import { EnemyData } from './Enemy';
 import { ChoiceBubble } from './ChoiceBubble';
+import { Weapon } from './Weapon';
 import { Door } from './Door';
 import { DwMap } from './DwMap';
 import { Chest } from './Chest';
@@ -23,7 +24,7 @@ import { getSearchConversation } from './SearchConversations';
 import { SpellBubble } from '@/app/dw/SpellBubble';
 import { Spell } from '@/app/dw/Spell';
 
-type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION';
+type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION' | 'WEAPON_SELECTION';
 
 type UpdateFunction = (delta: number) => void;
 
@@ -37,6 +38,7 @@ export class RoamingState extends BaseState {
     private warpBubble?: ChoiceBubble<WarpLocation>;
     private cheatBubble?: ChoiceBubble<CheatOption>;
     private battleBubble?: ChoiceBubble<EnemyData>;
+    private weaponSelectBubble?: ChoiceBubble<Weapon>;
     private readonly stationaryTimer: Delay;
     private overnightDelay?: Delay;
     private readonly updateMethods: Map<RoamingSubState, UpdateFunction>;
@@ -67,6 +69,7 @@ export class RoamingState extends BaseState {
         this.updateMethods.set('WARP_SELECTION', this.updateWarpSelection.bind(this));
         this.updateMethods.set('CHEAT_SELECTION', this.updateCheatSelection.bind(this));
         this.updateMethods.set('BATTLE_SELECTION', this.updateBattleSelection.bind(this));
+        this.updateMethods.set('WEAPON_SELECTION', this.updateWeaponSelection.bind(this));
 
         this.textBubble = new TextBubble(this.game);
         this.showTextBubble = false;
@@ -136,8 +139,7 @@ export class RoamingState extends BaseState {
                         this.game.audio.playSound('bump');
                         break;
                     case 'Weapon Change':
-                        this.game.cycleWeapon();
-                        this.setSubstate('ROAMING');
+                        this.setSubstate('WEAPON_SELECTION');
                         break;
                     case 'Armor Change':
                         this.game.cycleArmor();
@@ -385,6 +387,25 @@ export class RoamingState extends BaseState {
         }
     }
 
+    private updateWeaponSelection(delta: number) {
+
+        // Do check here to appease tsc of weaponSelectBubble being defined
+        this.weaponSelectBubble ??= Cheats.createWeaponSelectBubble(this.game);
+
+        this.weaponSelectBubble.update(delta);
+        if (this.weaponSelectBubble.handleInput()) {
+            const weapon: Weapon | undefined = this.weaponSelectBubble.getSelectedItem();
+            this.weaponSelectBubble = undefined;
+            if (weapon) {
+                this.game.hero.weapon = weapon;
+                this.game.setStatusMessage('Weapon changed to: ' + weapon.name);
+                this.setSubstate('ROAMING');
+            } else {
+                this.setSubstate('CHEAT_SELECTION');
+            }
+        }
+    }
+
     private overnightOver() {
         this.game.audio.playMusic('MUSIC_TOWN');
         delete this.overnightDelay;
@@ -500,6 +521,9 @@ export class RoamingState extends BaseState {
         }
         if (this.battleBubble) {
             this.battleBubble.paint(ctx);
+        }
+        if (this.weaponSelectBubble) {
+            this.weaponSelectBubble.paint(ctx);
         }
 
         if (this.overnightDelay) {


### PR DESCRIPTION
## Summary

Replaces the single-step "Weapon Change" cheat (which previously just cycled to the next weapon) with a proper `ChoiceBubble` that lists all available weapons sorted by ascending strength. Closes #112.

## Details

- Added `Cheats.createWeaponSelectBubble()` — builds a cancellable single-column `ChoiceBubble<Weapon>` with weapons sorted by `power` ascending, sized to fit the weapon list
- Added `WEAPON_SELECTION` substate to `RoamingState` with a corresponding `updateWeaponSelection()` method; selecting a weapon replaces the hero's current weapon and shows the same status message as the existing keyboard-shortcut path
- Cancelling the weapon select bubble returns the user to the Cheats bubble (via `CHEAT_SELECTION` substate)
- Updated rendering to paint the weapon select bubble when active
- Unit tests for `createWeaponSelectBubble()` covering sort order, sizing, cancel behavior, and selection

## Gif
![dwjs-cheat-weapon-select](https://github.com/user-attachments/assets/fdc0d07f-1506-44fa-abe2-015e92384790)

## Test plan

- [x] Open cheat menu (`COMMAND` → `Cheats` → `Weapon Change`) and verify a bubble listing all weapons appears
- [x] Verify weapons are listed in ascending order of strength
- [x] Select a weapon and verify the hero's weapon changes and the status message appears
- [x] Press cancel to verify the Cheats bubble is shown again (not the command menu)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)