### PR TITLE
feat: replace armor cycle cheat with interactive armor selection bubble

### DIFF
--- a/src/app/dw/Cheats.spec.ts
+++ b/src/app/dw/Cheats.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DwGame } from '@/app/dw/DwGame';
 import { Cheats } from '@/app/dw/Cheats';
 import { EnemyData } from '@/app/dw/Enemy';
+import { Armor } from '@/app/dw/Armor';
 import { ChoiceBubble } from '@/app/dw/ChoiceBubble';
 import { Weapon } from '@/app/dw/Weapon';
 
@@ -61,6 +62,12 @@ const metalScorpionData: EnemyData = {
     ai: 'attackOnly',
 };
 
+// 3 armors sorted by defense ascending (as LoadingState produces)
+const clothesArmor = new Armor('clothes', { name: 'clothes', displayName: 'Clothes', baseCost: 20, defense: 2 });
+const leatherArmor = new Armor('leatherArmor', { name: 'leatherArmor', displayName: 'Leather Armor', baseCost: 70, defense: 4 });
+const chainMail = new Armor('chainMail', { name: 'chainMail', displayName: 'Chain Mail', baseCost: 300, defense: 10 });
+const mockArmorArray: Armor[] = [ clothesArmor, leatherArmor, chainMail ];
+
 // 3 enemies: left column gets indices 0-1, right column gets index 2
 const mockEnemies: Record<string, EnemyData> = {
     Slime: slimeData,
@@ -77,6 +84,7 @@ describe('Cheats', () => {
         game.assets.set('font', mockFont);
         game.assets.set('enemies', mockEnemies);
         game.assets.set('weaponsArray', mockWeaponsArray);
+        game.assets.set('armorArray', mockArmorArray);
     });
 
     afterEach(() => {
@@ -157,6 +165,67 @@ describe('Cheats', () => {
                 expect(bubble.getSelectedItem()).toEqual(club);
             });
         });
+
+    });
+
+    describe('createArmorSelectBubble()', () => {
+
+        let bubble: ChoiceBubble<Armor>;
+
+        beforeEach(() => {
+            bubble = Cheats.createArmorSelectBubble(game);
+        });
+
+        it('has title "ARMOR"', () => {
+            expect(bubble.title).toEqual('ARMOR');
+        });
+
+        it('selects the first armor by default', () => {
+            expect(bubble.getSelectedIndex()).toEqual(0);
+            expect(bubble.getSelectedItem()).toEqual(clothesArmor);
+        });
+
+        it('has width based on game width and tile size', () => {
+            expect(bubble.w).toEqual(game.getWidth() - 4 * game.getTileSize());
+        });
+
+        it('has height based on armor count', () => {
+            expect(bubble.h).toEqual(mockArmorArray.length * 18 * game.scale + 1.5 * game.getTileSize());
+        });
+
+        it('uses displayName as the label for each armor', () => {
+            // Navigate to the second item and verify it's the correct armor
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'down').mockReturnValue(true);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+
+            bubble.handleInput();
+
+            expect(bubble.getSelectedItem()).toEqual(leatherArmor);
+            expect(bubble.getSelectedItem()?.displayName).toEqual('Leather Armor');
+        });
+
+        describe('when cancelled', () => {
+
+            it('marks input as handled and returns no selected item', () => {
+                vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(true);
+                vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'down').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+
+                const done = bubble.handleInput();
+
+                expect(done).toEqual(true);
+                expect(bubble.getSelectedItem()).toBeUndefined();
+                expect(bubble.getSelectedIndex()).toEqual(-1);
+            });
+        });
+
     });
 
     describe('createBattleBubble()', () => {

--- a/src/app/dw/Cheats.ts
+++ b/src/app/dw/Cheats.ts
@@ -2,6 +2,7 @@ import { Direction } from './Direction';
 import { DwGame } from './DwGame';
 import { ChoiceBubble } from './ChoiceBubble';
 import { EnemyData } from './Enemy';
+import { Armor } from './Armor';
 import { Weapon } from './Weapon';
 
 export type CheatOption =
@@ -45,6 +46,18 @@ export class Cheats {
         ];
 
         return new ChoiceBubble(game, x, y, w, h, choices, undefined, true);
+    }
+
+    static createArmorSelectBubble(game: DwGame): ChoiceBubble<Armor> {
+
+        const tileSize: number = game.getTileSize();
+        const choices: Armor[] = game.assets.get('armorArray');
+        const w: number = game.getWidth() - 4 * tileSize;
+        const h: number = choices.length * 18 * game.scale + 1.5 * tileSize;
+        const x: number = (game.getWidth() - w) / 2;
+        const y: number = (game.getHeight() - h) / 2;
+
+        return new ChoiceBubble(game, x, y, w, h, choices, (armor) => armor.displayName, true, 'ARMOR');
     }
 
     static createBattleBubble(game: DwGame): ChoiceBubble<EnemyData> {

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -13,6 +13,7 @@ import { Hero } from './Hero';
 import { MapLogic } from './mapLogic/MapLogic';
 import { CheatOption, Cheats, WarpLocation } from './Cheats';
 import { EnemyData } from './Enemy';
+import { Armor } from './Armor';
 import { ChoiceBubble } from './ChoiceBubble';
 import { Weapon } from './Weapon';
 import { Door } from './Door';
@@ -24,7 +25,7 @@ import { getSearchConversation } from './SearchConversations';
 import { SpellBubble } from '@/app/dw/SpellBubble';
 import { Spell } from '@/app/dw/Spell';
 
-type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION' | 'WEAPON_SELECTION';
+type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION' | 'WEAPON_SELECTION' | 'ARMOR_SELECTION';
 
 type UpdateFunction = (delta: number) => void;
 
@@ -39,6 +40,7 @@ export class RoamingState extends BaseState {
     private cheatBubble?: ChoiceBubble<CheatOption>;
     private battleBubble?: ChoiceBubble<EnemyData>;
     private weaponSelectBubble?: ChoiceBubble<Weapon>;
+    private armorBubble?: ChoiceBubble<Armor>;
     private readonly stationaryTimer: Delay;
     private overnightDelay?: Delay;
     private readonly updateMethods: Map<RoamingSubState, UpdateFunction>;
@@ -70,6 +72,7 @@ export class RoamingState extends BaseState {
         this.updateMethods.set('CHEAT_SELECTION', this.updateCheatSelection.bind(this));
         this.updateMethods.set('BATTLE_SELECTION', this.updateBattleSelection.bind(this));
         this.updateMethods.set('WEAPON_SELECTION', this.updateWeaponSelection.bind(this));
+        this.updateMethods.set('ARMOR_SELECTION', this.updateArmorSelection.bind(this));
 
         this.textBubble = new TextBubble(this.game);
         this.showTextBubble = false;
@@ -142,8 +145,7 @@ export class RoamingState extends BaseState {
                         this.setSubstate('WEAPON_SELECTION');
                         break;
                     case 'Armor Change':
-                        this.game.cycleArmor();
-                        this.setSubstate('ROAMING');
+                        this.setSubstate('ARMOR_SELECTION');
                         break;
                     case 'Shield Change':
                         this.game.cycleShield();
@@ -406,6 +408,25 @@ export class RoamingState extends BaseState {
         }
     }
 
+    private updateArmorSelection(delta: number) {
+
+        // Do check here to appease tsc of armorBubble being defined
+        this.armorBubble ??= Cheats.createArmorSelectBubble(this.game);
+
+        this.armorBubble.update(delta);
+        if (this.armorBubble.handleInput()) {
+            const armor = this.armorBubble.getSelectedItem();
+            this.armorBubble = undefined;
+            if (armor) {
+                this.game.hero.armor = armor;
+                this.game.setStatusMessage(`Armor changed to: ${armor.displayName}`);
+                this.setSubstate('ROAMING');
+            } else {
+                this.setSubstate('CHEAT_SELECTION');
+            }
+        }
+    }
+
     private overnightOver() {
         this.game.audio.playMusic('MUSIC_TOWN');
         delete this.overnightDelay;
@@ -524,6 +545,9 @@ export class RoamingState extends BaseState {
         }
         if (this.weaponSelectBubble) {
             this.weaponSelectBubble.paint(ctx);
+        }
+        if (this.armorBubble) {
+            this.armorBubble.paint(ctx);
         }
 
         if (this.overnightDelay) {


### PR DESCRIPTION
## Summary

Replaces the sequential armor-cycling cheat with a proper selection bubble, consistent with how the battle cheat works. Users can now pick any armor from an ordered list and cancel back to the cheat menu without closing it.

## Details

- Added `Cheats.createArmorSelectBubble()` that builds a `ChoiceBubble<Armor>` displaying all armors sorted by defense ascending, using `displayName` as the label, with a cancellable `ARMOR` title
- Added `ARMOR_SELECTION` substate to `RoamingState`, with a dedicated `updateArmorSelection()` update method and render support
- Selecting an armor equips it and shows a status message; cancelling returns to the cheat menu (`CHEAT_SELECTION`) rather than closing it
- Added comprehensive unit tests for `createArmorSelectBubble()` covering title, default selection, dimensions, display name rendering, and cancellation

## Gif
![dwjs-cheat-armor-select](https://github.com/user-attachments/assets/fcf4967d-93b5-4e9c-82c1-2f804fd65ad5)

## Test plan

- [x] Open cheat menu and select "Armor Change" — armor selection bubble appears with all armors listed in ascending defense order
- [x] Select an armor — hero's armor changes and status message confirms the change
- [x] Press cancel in the armor bubble — returns to the cheat menu (not the main command menu)

Closes #113

🤖 Generated with [Claude Code](https://claude.ai/claude-code)