### PR TITLE
feat: replace Shield Change cheat with a shield select bubble

### DIFF
--- a/src/app/dw/Cheats.spec.ts
+++ b/src/app/dw/Cheats.spec.ts
@@ -4,6 +4,7 @@ import { Cheats } from '@/app/dw/Cheats';
 import { EnemyData } from '@/app/dw/Enemy';
 import { Armor } from '@/app/dw/Armor';
 import { ChoiceBubble } from '@/app/dw/ChoiceBubble';
+import { Shield } from '@/app/dw/Shield';
 import { Weapon } from '@/app/dw/Weapon';
 
 const mockFont = {
@@ -75,6 +76,11 @@ const mockEnemies: Record<string, EnemyData> = {
     MetalScorpion: metalScorpionData,
 };
 
+// Shields in ascending defense order (as createShieldArray would produce)
+const smallShield = new Shield('smallShield', { name: 'smallShield', displayName: 'Small Shield', defense: 4 });
+const largeShield = new Shield('largeShield', { name: 'largeShield', displayName: 'Large Shield', defense: 10 });
+const mockShieldArray: Shield[] = [ smallShield, largeShield ];
+
 describe('Cheats', () => {
 
     let game: DwGame;
@@ -85,6 +91,7 @@ describe('Cheats', () => {
         game.assets.set('enemies', mockEnemies);
         game.assets.set('weaponsArray', mockWeaponsArray);
         game.assets.set('armorArray', mockArmorArray);
+        game.assets.set('shieldArray', mockShieldArray);
     });
 
     afterEach(() => {
@@ -273,5 +280,78 @@ describe('Cheats', () => {
             });
         });
 
+    });
+
+    describe('createShieldSelectBubble()', () => {
+
+        let bubble: ChoiceBubble<Shield>;
+
+        beforeEach(() => {
+            bubble = Cheats.createShieldSelectBubble(game);
+        });
+
+        it('has title "SHIELD"', () => {
+            expect(bubble.title).toEqual('SHIELD');
+        });
+
+        it('selects the first shield by default', () => {
+            expect(bubble.getSelectedIndex()).toEqual(0);
+            expect(bubble.getSelectedItem()).toEqual(smallShield);
+        });
+
+        it('has shields in ascending defense order', () => {
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValue(true);
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'down').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+
+            bubble.handleInput();
+
+            expect(bubble.getSelectedItem()).toEqual(smallShield);
+        });
+
+        it('uses displayName as the choice label', () => {
+            vi.spyOn(game.inputManager, 'down').mockReturnValueOnce(true).mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValueOnce(false).mockReturnValue(true);
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+
+            bubble.handleInput(); // navigate down to largeShield
+            bubble.handleInput(); // confirm largeShield
+
+            expect(bubble.getSelectedItem()).toEqual(largeShield);
+            expect(bubble.getSelectedItem()?.displayName).toEqual('Large Shield');
+        });
+
+        it('has width based on game width and tile size', () => {
+            expect(bubble.w).toEqual(game.getWidth() - 4 * game.getTileSize());
+        });
+
+        it('has height based on shield count', () => {
+            const lineHeight = 18;
+            expect(bubble.h).toEqual(mockShieldArray.length * lineHeight * game.scale + 1.5 * game.getTileSize());
+        });
+
+        describe('when cancelled', () => {
+
+            it('marks input as handled and returns no selected item', () => {
+                vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(true);
+                vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'down').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+                vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+
+                const done = bubble.handleInput();
+
+                expect(done).toEqual(true);
+                expect(bubble.getSelectedItem()).toBeUndefined();
+                expect(bubble.getSelectedIndex()).toEqual(-1);
+            });
+        });
     });
 });

--- a/src/app/dw/Cheats.ts
+++ b/src/app/dw/Cheats.ts
@@ -3,6 +3,7 @@ import { DwGame } from './DwGame';
 import { ChoiceBubble } from './ChoiceBubble';
 import { EnemyData } from './Enemy';
 import { Armor } from './Armor';
+import { Shield } from './Shield';
 import { Weapon } from './Weapon';
 
 export type CheatOption =
@@ -74,6 +75,19 @@ export class Cheats {
             (data) => data.shortName ?? data.name, true, 'BATTLE', 2);
         bubble.setYInc(lineHeight);
         return bubble;
+    }
+
+    static createShieldSelectBubble(game: DwGame): ChoiceBubble<Shield> {
+
+        const lineHeight = 18;
+        const tileSize: number = game.getTileSize();
+        const choices: Shield[] = game.getShieldArray();
+        const w: number = game.getWidth() - 4 * tileSize;
+        const h: number = choices.length * lineHeight * game.scale + 1.5 * tileSize;
+        const x: number = (game.getWidth() - w) / 2;
+        const y: number = (game.getHeight() - h) / 2;
+
+        return new ChoiceBubble(game, x, y, w, h, choices, (shield) => shield.displayName, true, 'SHIELD');
     }
 
     static createWeaponSelectBubble(game: DwGame): ChoiceBubble<Weapon> {

--- a/src/app/dw/DwGame.spec.ts
+++ b/src/app/dw/DwGame.spec.ts
@@ -10,12 +10,17 @@ import {
 import { EnemyData } from '@/app/dw/Enemy';
 import { BattleState } from '@/app/dw/BattleState';
 import { BattleTransitionState } from '@/app/dw/BattleTransitionState';
+import { Shield } from '@/app/dw/Shield';
 
 const mockFont = { cellW: 8, cellH: 9 };
 
 const mockWeapons = { club: { name: 'club' }, bambooStick: { name: 'bambooStick' } };
 const mockArmor = { clothes: { name: 'clothes' }, leather: { name: 'leather' } };
 const mockShields = { smallShield: { name: 'smallShield' }, largeShield: { name: 'largeShield' } };
+
+const smallShield = new Shield('smallShield', { name: 'smallShield', displayName: 'Small Shield', defense: 4 });
+const largeShield = new Shield('largeShield', { name: 'largeShield', displayName: 'Large Shield', defense: 10 });
+const mockShieldArray: Shield[] = [ smallShield, largeShield ];
 
 const slimeData: EnemyData = {
     name: 'Slime',
@@ -55,6 +60,7 @@ describe('DwGame', () => {
         game.assets.set('weapons', mockWeapons);
         game.assets.set('armor', mockArmor);
         game.assets.set('shields', mockShields);
+        game.assets.set('shieldArray', mockShieldArray);
         localStorage.clear();
     });
 
@@ -248,10 +254,39 @@ describe('DwGame', () => {
             game2.assets.set('weapons', mockWeapons);
             game2.assets.set('armor', mockArmor);
             game2.assets.set('shields', mockShields);
+            game2.assets.set('shieldArray', mockShieldArray);
             game2.loadAdventureLog();
             game2.saveAdventureLog();
 
             expect(getAdventureLogSummaries()).toHaveLength(2);
+        });
+    });
+
+    describe('getShieldArray()', () => {
+
+        it('returns the shield array from assets', () => {
+            expect(game.getShieldArray()).toEqual(mockShieldArray);
+        });
+    });
+
+    describe('setShield()', () => {
+
+        beforeEach(() => {
+            game.loadAdventureLog();
+        });
+
+        it('updates the hero shield', () => {
+            game.setShield(largeShield);
+
+            expect(game.hero.shield).toEqual(largeShield);
+        });
+
+        it('displays a status message with the shield name', () => {
+            const setStatusMessage = vi.spyOn(game, 'setStatusMessage');
+
+            game.setShield(largeShield);
+
+            expect(setStatusMessage).toHaveBeenCalledWith('Shield changed to: largeShield');
         });
     });
 });

--- a/src/app/dw/DwGame.ts
+++ b/src/app/dw/DwGame.ts
@@ -144,9 +144,13 @@ export class DwGame extends Game {
                 }
             }
             i = (i + 1) % shieldArray.length;
-            this.hero.shield = shieldArray[ i ];
-            this.setStatusMessage(`Shield changed to: ${this.hero.shield.name}`);
+            this.setShield(shieldArray[ i ]);
         }
+    }
+
+    setShield(shield: Shield) {
+        this.hero.shield = shield;
+        this.setStatusMessage(`Shield changed to: ${shield.name}`);
     }
 
     cycleWeapon() {
@@ -670,6 +674,10 @@ export class DwGame extends Game {
     getShield(shield: string): Shield {
         const shieldMap: EquipmentMap<Shield> = this.assets.get('shields');
         return shieldMap[ shield ];
+    }
+
+    getShieldArray(): Shield[] {
+        return this.assets.get('shieldArray');
     }
 
     getTileSize(): number {

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -15,6 +15,7 @@ import { CheatOption, Cheats, WarpLocation } from './Cheats';
 import { EnemyData } from './Enemy';
 import { Armor } from './Armor';
 import { ChoiceBubble } from './ChoiceBubble';
+import { Shield } from './Shield';
 import { Weapon } from './Weapon';
 import { Door } from './Door';
 import { DwMap } from './DwMap';
@@ -25,7 +26,7 @@ import { getSearchConversation } from './SearchConversations';
 import { SpellBubble } from '@/app/dw/SpellBubble';
 import { Spell } from '@/app/dw/Spell';
 
-type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION' | 'WEAPON_SELECTION' | 'ARMOR_SELECTION';
+type RoamingSubState = 'ROAMING' | 'MENU' | 'TALKING' | 'OVERNIGHT' | 'WARP_SELECTION' | 'CHEAT_SELECTION' | 'BATTLE_SELECTION' | 'WEAPON_SELECTION' | 'ARMOR_SELECTION' | 'SHIELD_SELECTION';
 
 type UpdateFunction = (delta: number) => void;
 
@@ -41,6 +42,7 @@ export class RoamingState extends BaseState {
     private battleBubble?: ChoiceBubble<EnemyData>;
     private weaponSelectBubble?: ChoiceBubble<Weapon>;
     private armorBubble?: ChoiceBubble<Armor>;
+    private shieldBubble?: ChoiceBubble<Shield>;
     private readonly stationaryTimer: Delay;
     private overnightDelay?: Delay;
     private readonly updateMethods: Map<RoamingSubState, UpdateFunction>;
@@ -73,6 +75,7 @@ export class RoamingState extends BaseState {
         this.updateMethods.set('BATTLE_SELECTION', this.updateBattleSelection.bind(this));
         this.updateMethods.set('WEAPON_SELECTION', this.updateWeaponSelection.bind(this));
         this.updateMethods.set('ARMOR_SELECTION', this.updateArmorSelection.bind(this));
+        this.updateMethods.set('SHIELD_SELECTION', this.updateShieldSelection.bind(this));
 
         this.textBubble = new TextBubble(this.game);
         this.showTextBubble = false;
@@ -148,8 +151,7 @@ export class RoamingState extends BaseState {
                         this.setSubstate('ARMOR_SELECTION');
                         break;
                     case 'Shield Change':
-                        this.game.cycleShield();
-                        this.setSubstate('ROAMING');
+                        this.setSubstate('SHIELD_SELECTION');
                         break;
                     case 'Max HP/MP':
                         this.game.setHeroStats(255, 255, 255, 255);
@@ -427,6 +429,24 @@ export class RoamingState extends BaseState {
         }
     }
 
+    private updateShieldSelection(delta: number) {
+
+        // Do check here to appease tsc of shieldBubble being defined
+        this.shieldBubble ??= Cheats.createShieldSelectBubble(this.game);
+
+        this.shieldBubble.update(delta);
+        if (this.shieldBubble.handleInput()) {
+            const shield = this.shieldBubble.getSelectedItem();
+            this.shieldBubble = undefined;
+            if (shield) {
+                this.game.setShield(shield);
+                this.setSubstate('ROAMING');
+            } else {
+                this.setSubstate('CHEAT_SELECTION');
+            }
+        }
+    }
+
     private overnightOver() {
         this.game.audio.playMusic('MUSIC_TOWN');
         delete this.overnightDelay;
@@ -548,6 +568,9 @@ export class RoamingState extends BaseState {
         }
         if (this.armorBubble) {
             this.armorBubble.paint(ctx);
+        }
+        if (this.shieldBubble) {
+            this.shieldBubble.paint(ctx);
         }
 
         if (this.overnightDelay) {


### PR DESCRIPTION
## Summary

Replaces the `Shield Change` cheat menu item's old behavior (cycling to the next shield) with a new `ChoiceBubble`-based shield selector. The player can now pick any shield directly by name, or press cancel to return to the Cheats bubble.

## Details

- Added `createShieldSelectBubble()` to `Cheats.ts` — lists all shields in ascending defense order using their display name, single-column, cancellable, sized to fit the shield count
- Added `getShieldArray()` to `DwGame` to expose the pre-sorted shield asset
- Extracted `setShield(shield)` from `cycleShield()` in `DwGame` to avoid duplicating the hero-assignment and status-message logic
- Added `SHIELD_SELECTION` substate to `RoamingState` with a matching `updateShieldSelection()` handler; cancelling returns to `CHEAT_SELECTION`, selecting a shield applies it and returns to `ROAMING`
- Unit tests for `createShieldSelectBubble()`, `getShieldArray()`, and `setShield()`

Closes #114

## Gif
![dwjs-cheat-shield-select](https://github.com/user-attachments/assets/090119e1-1139-42fc-a2ab-7619065f8a15)

## Test plan

- [x] Open the Cheats menu (`COMMAND` → `Cheats`) and select `Shield Change`
- [x] Verify a single-column bubble appears listing all shields in ascending defense order by display name
- [x] Select a shield and verify the hero's shield is updated and a status message appears in the bottom-left
- [x] Open the shield select bubble and press cancel — verify it closes and the Cheats bubble remains visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)