### PR TITLE
feat: support colored text spans in bubble text

### DIFF
--- a/src/app/dw/Bubble.spec.ts
+++ b/src/app/dw/Bubble.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { Bubble, BreakApartDelay, ColoredTextSpan } from '@/app/dw/Bubble';
+
+describe('Bubble', () => {
+
+    describe('removeSpecialEscapes()', () => {
+
+        describe('delay escapes', () => {
+
+            it('returns text unchanged when there are no escapes', () => {
+                const delays: BreakApartDelay[] = [];
+                const result = Bubble.removeSpecialEscapes('Hello world', delays);
+                expect(result).toEqual('Hello world');
+                expect(delays).toEqual([]);
+            });
+
+            it('removes a default delay escape and records its offset', () => {
+                const delays: BreakApartDelay[] = [];
+                const result = Bubble.removeSpecialEscapes('Hello\\d world', delays);
+                expect(result).toEqual('Hello world');
+                expect(delays).toEqual([ { offs: 5, millis: 500 } ]);
+            });
+
+            it('removes a timed delay escape and records its offset and duration', () => {
+                const delays: BreakApartDelay[] = [];
+                const result = Bubble.removeSpecialEscapes('Hi\\d{750}!', delays);
+                expect(result).toEqual('Hi!');
+                expect(delays).toEqual([ { offs: 2, millis: 750 } ]);
+            });
+
+            it('handles multiple delay escapes', () => {
+                const delays: BreakApartDelay[] = [];
+                const result = Bubble.removeSpecialEscapes('A\\dB\\d{200}C', delays);
+                expect(result).toEqual('ABC');
+                expect(delays).toHaveLength(2);
+                expect(delays[0]).toEqual({ offs: 1, millis: 500 });
+                expect(delays[1]).toEqual({ offs: 2, millis: 200 });
+            });
+        });
+
+        describe('color escapes', () => {
+
+            it('strips color escapes from text even when colorSpans is omitted', () => {
+                const delays: BreakApartDelay[] = [];
+                const result = Bubble.removeSpecialEscapes('\\c{red}Hi\\c', delays);
+                expect(result).toEqual('Hi');
+                expect(delays).toEqual([]);
+            });
+
+            it('removes a color escape and records the span', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes('Hello \\c{red}world\\c!', delays, colorSpans);
+                expect(result).toEqual('Hello world!');
+                expect(colorSpans).toEqual([ { colorId: 'red', offs: 6, count: 5 } ]);
+            });
+
+            it('records start at 0 when the span is at the beginning', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes('\\c{blue}Hi\\c there', delays, colorSpans);
+                expect(result).toEqual('Hi there');
+                expect(colorSpans).toEqual([ { colorId: 'blue', offs: 0, count: 2 } ]);
+            });
+
+            it('records the span covering text to the end of the string', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes('Go \\c{green}now\\c', delays, colorSpans);
+                expect(result).toEqual('Go now');
+                expect(colorSpans).toEqual([ { colorId: 'green', offs: 3, count: 3 } ]);
+            });
+
+            it('handles multiple color spans', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes(
+                    '\\c{red}A\\c and \\c{blue}B\\c',
+                    delays,
+                    colorSpans,
+                );
+                expect(result).toEqual('A and B');
+                expect(colorSpans).toHaveLength(2);
+                expect(colorSpans[0]).toEqual({ colorId: 'red', offs: 0, count: 1 });
+                expect(colorSpans[1]).toEqual({ colorId: 'blue', offs: 6, count: 1 });
+            });
+
+            it('handles a color id with hyphens and underscores', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes(
+                    '\\c{hero-name_color}Hi\\c',
+                    delays,
+                    colorSpans,
+                );
+                expect(result).toEqual('Hi');
+                expect(colorSpans).toEqual([ { colorId: 'hero-name_color', offs: 0, count: 2 } ]);
+            });
+
+            it('produces an empty span when there is no text between opening and closing escapes', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes('\\c{red}\\c', delays, colorSpans);
+                expect(result).toEqual('');
+                expect(colorSpans).toEqual([ { colorId: 'red', offs: 0, count: 0 } ]);
+            });
+        });
+
+        describe('mixed delay and color escapes', () => {
+
+            it('handles a delay followed by a color span', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes(
+                    'Wait\\d then \\c{red}stop\\c',
+                    delays,
+                    colorSpans,
+                );
+                expect(result).toEqual('Wait then stop');
+                expect(delays).toEqual([ { offs: 4, millis: 500 } ]);
+                expect(colorSpans).toEqual([ { colorId: 'red', offs: 10, count: 4 } ]);
+            });
+
+            it('handles a color span followed by a delay', () => {
+                const delays: BreakApartDelay[] = [];
+                const colorSpans: ColoredTextSpan[] = [];
+                const result = Bubble.removeSpecialEscapes(
+                    '\\c{red}go\\c\\d{300} now',
+                    delays,
+                    colorSpans,
+                );
+                expect(result).toEqual('go now');
+                expect(colorSpans).toEqual([ { colorId: 'red', offs: 0, count: 2 } ]);
+                expect(delays).toEqual([ { offs: 2, millis: 300 } ]);
+            });
+        });
+    });
+});

--- a/src/app/dw/Bubble.ts
+++ b/src/app/dw/Bubble.ts
@@ -6,9 +6,16 @@ export interface BreakApartDelay {
     millis: number;
 }
 
+export interface ColoredTextSpan {
+    colorId: string;
+    offs: number;
+    count: number;
+}
+
 export interface BreakApartResult {
     lines: string[];
     delays: BreakApartDelay[];
+    lineColorSpans: ColoredTextSpan[][];
 }
 
 /**
@@ -70,63 +77,131 @@ export class Bubble {
         this.setActive(true);
     }
 
+    /**
+     * Takes a string of text (say from a segment) and breaks it into multiple lines. Handles
+     * both `\n` representing newlines and the string being too wide for the bubble's width.
+     * @param text The text to break apart.
+     * @param w The maximum width.
+     */
     protected breakApart(text: string, w: number): BreakApartResult {
 
-        const result: BreakApartResult = { lines: [], delays: [] };
+        const result: BreakApartResult = { lines: [], delays: [], lineColorSpans: [] };
+        const allColorSpans: ColoredTextSpan[] = [];
 
         // Newlines are automatic line breaks
-        text = Bubble.removeSpecialEscapes(text, result.delays);
+        text = Bubble.removeSpecialEscapes(text, result.delays, allColorSpans);
         const lineList: string[] = text.split('\n');
 
+        let globalOffset = 0;
         lineList.forEach((line) => {
-            this.breakApartLine(line, w, result);
+            this.breakApartLine(line, w, result, globalOffset, allColorSpans);
+            globalOffset += line.length + 1; // +1 for the '\n' separator
         });
         return result;
     }
 
     /**
-     * Locates special escapes in text and adds entries into the appropriate
-     * arrays (delays, font color changes, etc.).
+     * Locates special escapes in text and removes them, recording their positions in the
+     * appropriate output arrays. All offsets are relative to the final cleaned text.
+     *
+     * Supported escape formats:
+     *   Delays: `\d{750}` (750 ms), `\d` (default 500 ms)
+     *   Colors: `\c{colorId}text\c` where colorId is letters, digits, underscores, or hyphens
      *
      * @param text The text to scan.
      * @param delays The array to put delays into.
-     * @return The text, with any escapes removed.
+     * @param colorSpans The optional array to put color spans into. Optional, but note color escapes
+     *        are still removed even if this is not provided. Only omittable for code that doesn't need
+     *        or want color spans.
+     * @return The text, with any processed escapes removed.
      */
-    static removeSpecialEscapes(text: string, delays: BreakApartDelay[]) {
+    static removeSpecialEscapes(text: string, delays: BreakApartDelay[], colorSpans?: ColoredTextSpan[]) {
 
-        // Delay formats:
-        //    \d{750} - 750ms
-        //    \d      - default (500ms)
+        // Single-pass scan so that all offsets are relative to the same fully cleaned text,
+        // regardless of the order in which delay and color escapes appear.
+        let i = 0;
+        let pendingColorId: string | null = null;
+        let pendingColorStart = 0;
 
-        let delay: number;
-        let index: number;
-        let lastOffs = 0;
-        while ((index = text.indexOf('\\d', lastOffs)) > -1) {
-
-            if (index + 2 < text.length && text.charAt(index + 2) === '{') {
-                const end: number = text.indexOf('}', index + 3);
-                if (end > -1) {
-                    delay = parseInt(text.substring(index + 3, end), 10);
-                    console.log(`Adding a delay of ${delay} ms`);
-                    delays.push({ offs: index, millis: delay });
-                    text = text.substring(0, index) + text.substring(end + 1);
-                } else {
-                    console.warn(`Suspicious, apparent unclosed delay at offset ${index}`);
-                }
-            } else {
-                delay = 500;
-                console.log(`Adding the default delay of ${delay} ms`);
-                delays.push({ offs: index, millis: delay });
-                text = text.substring(0, index) + text.substring(index + 2);
+        while (i < text.length) {
+            if (text[i] !== '\\') {
+                i++;
+                continue;
             }
 
-            lastOffs = index;
+            const next = text[i + 1];
+
+            // Delay escape: \d{N} or \d
+            if (next === 'd') {
+                if (i + 2 < text.length && text[i + 2] === '{') {
+                    const end = text.indexOf('}', i + 3);
+                    if (end > -1) {
+                        const millis = parseInt(text.substring(i + 3, end), 10);
+                        console.log(`Adding a delay of ${millis} ms`);
+                        delays.push({ offs: i, millis });
+                        text = text.substring(0, i) + text.substring(end + 1);
+                        continue; // i is now positioned at the character that followed the escape
+                    }
+                    console.warn(`Suspicious, apparent unclosed delay at offset ${i}`);
+                    i++;
+                    continue;
+                }
+                console.log('Adding the default delay of 500 ms');
+                delays.push({ offs: i, millis: 500 });
+                text = text.substring(0, i) + text.substring(i + 2);
+                continue;
+            }
+
+            // Color escape: \c{colorId} (open) or \c (close)
+            if (next === 'c') {
+                if (i + 2 < text.length && text[i + 2] === '{') {
+                    // Opening: \c{colorId}
+                    const braceEnd = text.indexOf('}', i + 3);
+                    if (braceEnd > -1) {
+                        const colorId = text.substring(i + 3, braceEnd);
+                        if (pendingColorId !== null) {
+                            console.warn(`Nested color span at offset ${i} is not supported; overwriting previous span`);
+                        }
+                        text = text.substring(0, i) + text.substring(braceEnd + 1);
+                        pendingColorId = colorId;
+                        pendingColorStart = i;
+                        continue;
+                    }
+                    console.warn(`Malformed color escape at offset ${i}`);
+                    i += 3;
+                    continue;
+                }
+
+                // Closing: \c
+                if (pendingColorId !== null) {
+                    colorSpans?.push({ colorId: pendingColorId, offs: pendingColorStart, count: i - pendingColorStart });
+                    text = text.substring(0, i) + text.substring(i + 2);
+                    pendingColorId = null;
+                    continue;
+                }
+
+                // Stray closing \c with no open span — skip
+                i += 2;
+                continue;
+            }
+
+            i++;
+        }
+
+        if (pendingColorId !== null) {
+            console.warn(`Missing closing \\c for color span starting at ${pendingColorStart}`);
         }
 
         return text;
     }
 
-    private breakApartLine(line: string, w: number, result: BreakApartResult) {
+    /**
+     * Takes input text that may be longer than the bubble's viewport, and breaks it into
+     * multiple lines that fit within the bubble's width. Also adjusts the "colored spans"
+     * to accommodate being on multiple lines if necessary.
+     */
+    private breakApartLine(line: string, w: number, result: BreakApartResult, globalOffset: number,
+        allColorSpans: ColoredTextSpan[]) {
 
         const optimal: number = Math.floor(w / this.fontWidth);
 
@@ -137,14 +212,35 @@ export class Bubble {
             while (ch !== ' ') {
                 ch = line.charAt(--offs);
             }
+            result.lineColorSpans.push(Bubble.getColorSpansForLine(globalOffset, offs, allColorSpans));
             result.lines.push(line.substring(0, offs));
 
+            globalOffset += offs + 1; // +1 to skip the space consumed by trim()
             line = line.substring(offs).trim();
         }
 
         //if (line.length>0) {
+        result.lineColorSpans.push(Bubble.getColorSpansForLine(globalOffset, line.length, allColorSpans));
         result.lines.push(line);
         //}
+    }
+
+    /**
+     * Returns the color spans that apply to a line of text.
+     * @param lineStart The start of the line.
+     * @param lineLength The length of the line.
+     * @param allColorSpans All spans for the segment (could be multiple lines).
+     */
+    private static getColorSpansForLine(lineStart: number, lineLength: number,
+        allColorSpans: ColoredTextSpan[]): ColoredTextSpan[] {
+        const lineEnd = lineStart + lineLength;
+        return allColorSpans
+            .filter((s) => s.offs < lineEnd && s.offs + s.count > lineStart)
+            .map((s) => ({
+                colorId: s.colorId,
+                offs: Math.max(0, s.offs - lineStart),
+                count: Math.min(lineEnd, s.offs + s.count) - Math.max(lineStart, s.offs),
+            }));
     }
 
     protected drawArrow(x: number, y: number) {

--- a/src/app/dw/DwGame.spec.ts
+++ b/src/app/dw/DwGame.spec.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 import { DwGame } from '@/app/dw/DwGame';
+import { ColoredTextSpan } from '@/app/dw/Bubble';
 import {
     AdventureLog,
     createNewAdventureLog,
@@ -287,6 +288,73 @@ describe('DwGame', () => {
             game.setShield(largeShield);
 
             expect(setStatusMessage).toHaveBeenCalledWith('Shield changed to: largeShield');
+        });
+    });
+
+    describe('drawStringWithColor()', () => {
+
+        const fontW = mockFont.cellW;
+        let drawStringSpy: MockInstance<DwGame['drawString']>;
+
+        beforeEach(() => {
+            game.assets.set('font', mockFont);
+            drawStringSpy = vi.spyOn(game, 'drawString').mockImplementation(() => {});
+        });
+
+        it('calls drawString once with the full text when spans is empty', () => {
+            game.drawStringWithColor('Hello', [], 10, 20);
+            expect(drawStringSpy).toHaveBeenCalledExactlyOnceWith('Hello', 10, 20);
+        });
+
+        it('renders a span covering the entire text', () => {
+            const spans: ColoredTextSpan[] = [ { colorId: 'blue', offs: 0, count: 5 } ];
+            game.drawStringWithColor('Hello', spans, 10, 20);
+            expect(drawStringSpy).toHaveBeenCalledExactlyOnceWith('Hello', 10, 20, 'blue');
+        });
+
+        it('renders plain text before the span, then the colored span, then plain text after', () => {
+            const spans: ColoredTextSpan[] = [ { colorId: 'red', offs: 6, count: 5 } ];
+            game.drawStringWithColor('Hello world!', spans, 0, 0);
+            expect(drawStringSpy).toHaveBeenCalledTimes(3);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(1, 'Hello ', 0, 0);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(2, 'world', 6 * fontW, 0, 'red');
+            expect(drawStringSpy).toHaveBeenNthCalledWith(3, '!', 11 * fontW, 0);
+        });
+
+        it('renders a span at the start with plain text after', () => {
+            const spans: ColoredTextSpan[] = [ { colorId: 'green', offs: 0, count: 3 } ];
+            game.drawStringWithColor('Go now', spans, 4, 8);
+            expect(drawStringSpy).toHaveBeenCalledTimes(2);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(1, 'Go ', 4, 8, 'green');
+            expect(drawStringSpy).toHaveBeenNthCalledWith(2, 'now', 4 + 3 * fontW, 8);
+        });
+
+        it('renders plain text before a span at the end', () => {
+            const spans: ColoredTextSpan[] = [ { colorId: 'yellow', offs: 3, count: 3 } ];
+            game.drawStringWithColor('Go now', spans, 0, 0);
+            expect(drawStringSpy).toHaveBeenCalledTimes(2);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(1, 'Go ', 0, 0);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(2, 'now', 3 * fontW, 0, 'yellow');
+        });
+
+        it('renders multiple non-adjacent spans with plain text between them', () => {
+            const spans: ColoredTextSpan[] = [
+                { colorId: 'red', offs: 0, count: 1 },
+                { colorId: 'blue', offs: 6, count: 1 },
+            ];
+            game.drawStringWithColor('A and B', spans, 0, 0);
+            expect(drawStringSpy).toHaveBeenCalledTimes(3);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(1, 'A', 0, 0, 'red');
+            expect(drawStringSpy).toHaveBeenNthCalledWith(2, ' and ', 1 * fontW, 0);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(3, 'B', 6 * fontW, 0, 'blue');
+        });
+
+        it('advances drawX correctly for each segment', () => {
+            const spans: ColoredTextSpan[] = [ { colorId: 'red', offs: 3, count: 2 } ];
+            game.drawStringWithColor('abcDEfg', spans, 100, 50);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(1, 'abc', 100, 50);
+            expect(drawStringSpy).toHaveBeenNthCalledWith(2, 'DE', 100 + 3 * fontW, 50, 'red');
+            expect(drawStringSpy).toHaveBeenNthCalledWith(3, 'fg', 100 + 5 * fontW, 50);
         });
     });
 });

--- a/src/app/dw/DwGame.ts
+++ b/src/app/dw/DwGame.ts
@@ -49,6 +49,7 @@ import { RoamingEntityRange } from './RoamingEntity';
 import { HERB, Item, getItemByName } from '@/app/dw/Item';
 import { HiddenItem, HiddenItemType } from '@/app/dw/HiddenItem';
 import { Kol } from '@/app/dw/mapLogic/kol';
+import { ColoredTextSpan } from '@/app/dw/Bubble';
 
 
 export type TiledMapMap = Record<string, DwMap>;
@@ -198,6 +199,33 @@ export class DwGame extends Game {
     drawString(text: string | number, x: number, y: number, color?: string) {
         const textStr: string = typeof text === 'number' ? text.toString() : text;
         this.getFont().drawString(this.getRenderingContext(), textStr, x, y, color);
+    }
+
+    drawStringWithColor(text: string, spans: ColoredTextSpan[], x: number, y: number): void {
+        if (spans.length === 0) {
+            this.drawString(text, x, y);
+            return;
+        }
+
+        const fontW = this.stringWidth('x');
+        let pos = 0;
+        let drawX = x;
+
+        for (const span of spans) {
+            if (pos < span.offs) {
+                const before = text.substring(pos, span.offs);
+                this.drawString(before, drawX, y);
+                drawX += before.length * fontW;
+            }
+            const spanText = text.substring(span.offs, span.offs + span.count);
+            this.drawString(spanText, drawX, y, span.colorId);
+            drawX += spanText.length * fontW;
+            pos = span.offs + span.count;
+        }
+
+        if (pos < text.length) {
+            this.drawString(text.substring(pos), drawX, y);
+        }
     }
 
     getAdventureLog(): AdventureLog {

--- a/src/app/dw/TextBubble.ts
+++ b/src/app/dw/TextBubble.ts
@@ -1,5 +1,5 @@
 import { Delay } from 'gtp';
-import { Bubble,BreakApartDelay, BreakApartResult } from './Bubble';
+import { Bubble, BreakApartDelay, BreakApartResult, ColoredTextSpan } from './Bubble';
 import { DwGame } from './DwGame';
 import { ShoppingBubble } from './ShoppingBubble';
 import { Conversation } from './Conversation';
@@ -20,6 +20,7 @@ export class TextBubble extends Bubble {
     private curLine: number;
     private lines: string[];
     private delays: BreakApartDelay[];
+    private lineColorSpans: ColoredTextSpan[][];
     private curOffs: number;
     private curCharMillis: number;
     private textDone: boolean;
@@ -50,6 +51,7 @@ export class TextBubble extends Bubble {
         this.curLine = 0;
         this.lines = [];
         this.delays = [];
+        this.lineColorSpans = [];
         this.curOffs = -1;
         this.curCharMillis = 0;
         this.textDone = true;
@@ -81,6 +83,7 @@ export class TextBubble extends Bubble {
         const breakApartResult: BreakApartResult = this.breakApart(curText, w);
         this.lines = this.lines.concat(breakApartResult.lines);
         this.delays = breakApartResult.delays;
+        this.lineColorSpans = this.lineColorSpans.concat(breakApartResult.lineColorSpans);
         this.curOffs = -1;
         this.curCharMillis = 0;
         this.textDone = false;
@@ -169,7 +172,9 @@ export class TextBubble extends Bubble {
             if (!this.textDone) {
                 this.textDone = true;
                 if (this.lines.length > TextBubble.MAX_LINE_COUNT) {
-                    this.lines.splice(0, this.lines.length - TextBubble.MAX_LINE_COUNT);
+                    const removeCount = this.lines.length - TextBubble.MAX_LINE_COUNT;
+                    this.lines.splice(0, removeCount);
+                    this.lineColorSpans.splice(0, removeCount);
                 }
                 this.curLine = this.lines.length - 1;
             } else {
@@ -252,6 +257,12 @@ export class TextBubble extends Bubble {
         }
     }
 
+    private shiftLine(): void {
+        this.lines.shift();
+        this.lineColorSpans.shift();
+        this.curLine--;
+    }
+
     override updateImpl(delta: number): void {
 
         if (this.delay) {
@@ -266,8 +277,7 @@ export class TextBubble extends Bubble {
         if (this.textDone &&
                 this.curOffs === -1 && this.curLine === TextBubble.MAX_LINE_COUNT - 1 &&
                 this.conversation.hasNext()) {
-            this.lines.shift();
-            this.curLine--;
+            this.shiftLine();
         }
 
         if (!this.textDone) {
@@ -275,8 +285,7 @@ export class TextBubble extends Bubble {
             if (this.curCharMillis > TextBubble.CHAR_RENDER_MILLIS) {
                 this.curCharMillis -= TextBubble.CHAR_RENDER_MILLIS;
                 if (this.curOffs === -1 && this.curLine === TextBubble.MAX_LINE_COUNT) {
-                    this.lines.shift();
-                    this.curLine--;
+                    this.shiftLine();
                 }
                 // TODO: This could be more performant...
                 if (this.delays && this.delays.length > 0) {
@@ -348,7 +357,7 @@ export class TextBubble extends Bubble {
                     const end: number = Math.max(0, this.curOffs);
                     text = text.substring(0, end);
                 }
-                this.game.drawString(text, x, y);
+                this.game.drawStringWithColor(text, this.lineColorSpans[i], x, y);
                 y += 10 * this.game.scale;
             }
             if (this.textDone && this.conversation.hasNext()) {
@@ -394,6 +403,7 @@ export class TextBubble extends Bubble {
             const breakApartResult: BreakApartResult = this.breakApart(this.text, w);
             this.lines = breakApartResult.lines;
             this.delays = breakApartResult.delays;
+            this.lineColorSpans = breakApartResult.lineColorSpans;
             this.curLine = 0;
             this.curOffs = -1;
             this.curCharMillis = 0;


### PR DESCRIPTION
## Summary

Implements [GitHub issue #125](https://github.com/bobbylight/DragonWarriorJS/issues/125): support for colored text spans in bubble text. Color escapes can now be embedded in any conversation text using the format `\c{colorId}text\c`.

## Details

- Added `ColoredTextSpan { colorId, offs, count }` interface to `Bubble.ts`
- `removeSpecialEscapes()` now parses `\c{colorId}...\c` color escapes in a single pass alongside delay escapes, always stripping them from the output text (even if the optional `colorSpans` parameter is omitted)
- `BreakApartResult` now includes `lineColorSpans: ColoredTextSpan[][]` — one span array per output line, with offsets relative to that line
- `getColorSpansForLine()` projects global color spans to per-line local offsets, correctly handling spans that cross line breaks
- `TextBubble` stores `lineColorSpans: ColoredTextSpan[][]` parallel to `lines[]`, keeping all shift/splice operations symmetric
- `DwGame.drawStringWithColor()` renders a string with colored segments by iterating spans and calling `drawString` with an optional color argument per segment
- Color IDs are arbitrary identifiers (letters, digits, hyphens, underscores) — not CSS color strings; the rendering layer resolves them to actual colors

## Test plan

- [x] Verify colored NPC dialogue renders correctly in Brecconary
- [x] Unit tests added for `Bubble.removeSpecialEscapes()` covering delay escapes, color escapes, mixed escapes, and edge cases (13 tests)
- [x] Unit tests added for `DwGame.drawStringWithColor()` covering empty spans, full-text spans, span at start/middle/end, multiple spans, and correct x-position advancement (7 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)