### PR TITLE
feat: show stat delta with color in equipment selection bubbles

### DIFF
--- a/src/app/dw/Cheats.spec.ts
+++ b/src/app/dw/Cheats.spec.ts
@@ -445,4 +445,129 @@ describe('Cheats', () => {
             });
         });
     });
+
+    describe('weaponStringifier()', () => {
+
+        it('returns only the displayName when delta is 0', () => {
+            expect(Cheats.weaponStringifier(bambooStick, 20, bambooStick.power)).toEqual('Bamboo Stick');
+        });
+
+        it('appends right-aligned "+N" with statIncrease color for positive delta', () => {
+            // currentPower 0, bambooStick.power = 2, delta = +2
+            const result = Cheats.weaponStringifier(bambooStick, 16, 0);
+            expect(result).toEqual('Bamboo Stick  \\c{statIncrease}+2\\c');
+        });
+
+        it('appends right-aligned "-N" with statDecrease color for negative delta', () => {
+            // currentPower = club.power (4), bambooStick.power = 2, delta = -2
+            const result = Cheats.weaponStringifier(bambooStick, 16, club.power);
+            expect(result).toEqual('Bamboo Stick  \\c{statDecrease}-2\\c');
+        });
+
+        it('the visible text is exactly contentCharWidth characters long', () => {
+            const contentCharWidth = 20;
+            const result = Cheats.weaponStringifier(bambooStick, contentCharWidth, 0);
+            // Strip escape sequences to get visible length
+            const visible = result.replace(/\\c\{[^}]+\}/g, '').replace(/\\c/g, '');
+            expect(visible.length).toEqual(contentCharWidth);
+        });
+    });
+
+    describe('armorStringifier()', () => {
+
+        it('returns only the displayName when delta is 0', () => {
+            expect(Cheats.armorStringifier(clothesArmor, 20, clothesArmor.defense)).toEqual('Clothes');
+        });
+
+        it('appends right-aligned "+N" with statIncrease color for positive delta', () => {
+            // currentDefense 0, clothesArmor.defense = 2, delta = +2
+            const result = Cheats.armorStringifier(clothesArmor, 12, 0);
+            expect(result).toEqual('Clothes   \\c{statIncrease}+2\\c');
+        });
+
+        it('appends right-aligned "-N" with statDecrease color for negative delta', () => {
+            // currentDefense = chainMail.defense (10), clothesArmor.defense = 2, delta = -8
+            const result = Cheats.armorStringifier(clothesArmor, 12, chainMail.defense);
+            expect(result).toEqual('Clothes   \\c{statDecrease}-8\\c');
+        });
+
+        it('the visible text is exactly contentCharWidth characters long', () => {
+            const contentCharWidth = 20;
+            const result = Cheats.armorStringifier(clothesArmor, contentCharWidth, 0);
+            const visible = result.replace(/\\c\{[^}]+\}/g, '').replace(/\\c/g, '');
+            expect(visible.length).toEqual(contentCharWidth);
+        });
+    });
+
+    describe('shieldStringifier()', () => {
+
+        it('returns only the displayName when delta is 0', () => {
+            expect(Cheats.shieldStringifier(smallShield, 20, smallShield.defense)).toEqual('Small Shield');
+        });
+
+        it('appends right-aligned "+N" with statIncrease color for positive delta', () => {
+            // currentDefense 0, smallShield.defense = 4, delta = +4
+            const result = Cheats.shieldStringifier(smallShield, 16, 0);
+            expect(result).toEqual('Small Shield  \\c{statIncrease}+4\\c');
+        });
+
+        it('appends right-aligned "-N" with statDecrease color for negative delta', () => {
+            // currentDefense = largeShield.defense (10), smallShield.defense = 4, delta = -6
+            const result = Cheats.shieldStringifier(smallShield, 16, largeShield.defense);
+            expect(result).toEqual('Small Shield  \\c{statDecrease}-6\\c');
+        });
+
+        it('the visible text is exactly contentCharWidth characters long', () => {
+            const contentCharWidth = 20;
+            const result = Cheats.shieldStringifier(smallShield, contentCharWidth, 0);
+            const visible = result.replace(/\\c\{[^}]+\}/g, '').replace(/\\c/g, '');
+            expect(visible.length).toEqual(contentCharWidth);
+        });
+    });
+
+    describe('createCheatBubble()', () => {
+
+        it('uses "Change Weapon..." as the label for the weapon cheat', () => {
+            const bubble = Cheats.createCheatBubble(game);
+            // Navigate down past 'Change Gold...' and 'Level Up' to 'Change Weapon...'
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'down').mockReturnValue(true);
+            bubble.handleInput(); // → 'Level Up'
+            bubble.handleInput(); // → 'Change Weapon...'
+            expect(bubble.getSelectedItem()).toEqual('Change Weapon...');
+        });
+
+        it('uses "Change Armor..." as the label for the armor cheat', () => {
+            const bubble = Cheats.createCheatBubble(game);
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'down').mockReturnValue(true);
+            bubble.handleInput(); // → 'Level Up'
+            bubble.handleInput(); // → 'Change Weapon...'
+            bubble.handleInput(); // → 'Change Armor...'
+            expect(bubble.getSelectedItem()).toEqual('Change Armor...');
+        });
+
+        it('uses "Change Shield..." as the label for the shield cheat', () => {
+            const bubble = Cheats.createCheatBubble(game);
+            vi.spyOn(game, 'cancelKeyPressed').mockReturnValue(false);
+            vi.spyOn(game, 'actionKeyPressed').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'up').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'left').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'right').mockReturnValue(false);
+            vi.spyOn(game.inputManager, 'down').mockReturnValue(true);
+            bubble.handleInput(); // → 'Level Up'
+            bubble.handleInput(); // → 'Change Weapon...'
+            bubble.handleInput(); // → 'Change Armor...'
+            bubble.handleInput(); // → 'Change Shield...'
+            expect(bubble.getSelectedItem()).toEqual('Change Shield...');
+        });
+    });
 });

--- a/src/app/dw/Cheats.ts
+++ b/src/app/dw/Cheats.ts
@@ -9,9 +9,9 @@ import { Weapon } from './Weapon';
 export type CheatOption =
     'Change Gold...' |
     'Level Up' |
-    'Weapon Change' |
-    'Armor Change' |
-    'Shield Change' |
+    'Change Weapon...' |
+    'Change Armor...' |
+    'Change Shield...' |
     'Max HP/MP' |
     'Min HP/MP' |
     'Battle...';
@@ -40,9 +40,9 @@ export class Cheats {
         const choices: CheatOption[] = [
             'Change Gold...',
             'Level Up',
-            'Weapon Change',
-            'Armor Change',
-            'Shield Change',
+            'Change Weapon...',
+            'Change Armor...',
+            'Change Shield...',
             'Max HP/MP',
             'Min HP/MP',
             'Battle...',
@@ -63,6 +63,14 @@ export class Cheats {
         return new ChoiceBubble(game, x, y, w, h, choices, undefined, true, 'GOLD');
     }
 
+    static armorStringifier(armor: Armor, contentCharWidth: number, currentDefense: number): string {
+        const delta = armor.defense - currentDefense;
+        if (delta === 0) return armor.displayName;
+        const statStr = delta > 0 ? `+${delta}` : `${delta}`;
+        const colorId = delta > 0 ? 'statIncrease' : 'statDecrease';
+        return `${armor.displayName.padEnd(contentCharWidth - statStr.length)}\\c{${colorId}}${statStr}\\c`;
+    }
+
     static createArmorSelectBubble(game: DwGame): ChoiceBubble<Armor> {
 
         const tileSize: number = game.getTileSize();
@@ -72,7 +80,9 @@ export class Cheats {
         const x: number = (game.getWidth() - w) / 2;
         const y: number = (game.getHeight() - h) / 2;
 
-        return new ChoiceBubble(game, x, y, w, h, choices, (armor) => armor.displayName, true, 'ARMOR');
+        const currentDefense = game.hero.armor?.defense ?? 0;
+        return new ChoiceBubble(game, x, y, w, h, choices,
+            (armor, w) => Cheats.armorStringifier(armor, w, currentDefense), true, 'ARMOR');
     }
 
     static createBattleBubble(game: DwGame): ChoiceBubble<EnemyData> {
@@ -91,6 +101,14 @@ export class Cheats {
         return bubble;
     }
 
+    static shieldStringifier(shield: Shield, contentCharWidth: number, currentDefense: number): string {
+        const delta = shield.defense - currentDefense;
+        if (delta === 0) return shield.displayName;
+        const statStr = delta > 0 ? `+${delta}` : `${delta}`;
+        const colorId = delta > 0 ? 'statIncrease' : 'statDecrease';
+        return `${shield.displayName.padEnd(contentCharWidth - statStr.length)}\\c{${colorId}}${statStr}\\c`;
+    }
+
     static createShieldSelectBubble(game: DwGame): ChoiceBubble<Shield> {
 
         const lineHeight = 18;
@@ -101,7 +119,17 @@ export class Cheats {
         const x: number = (game.getWidth() - w) / 2;
         const y: number = (game.getHeight() - h) / 2;
 
-        return new ChoiceBubble(game, x, y, w, h, choices, (shield) => shield.displayName, true, 'SHIELD');
+        const currentDefense = game.hero.shield?.defense ?? 0;
+        return new ChoiceBubble(game, x, y, w, h, choices,
+            (shield, w) => Cheats.shieldStringifier(shield, w, currentDefense), true, 'SHIELD');
+    }
+
+    static weaponStringifier(weapon: Weapon, contentCharWidth: number, currentPower: number): string {
+        const delta = weapon.power - currentPower;
+        if (delta === 0) return weapon.displayName;
+        const statStr = delta > 0 ? `+${delta}` : `${delta}`;
+        const colorId = delta > 0 ? 'statIncrease' : 'statDecrease';
+        return `${weapon.displayName.padEnd(contentCharWidth - statStr.length)}\\c{${colorId}}${statStr}\\c`;
     }
 
     static createWeaponSelectBubble(game: DwGame): ChoiceBubble<Weapon> {
@@ -114,7 +142,9 @@ export class Cheats {
         const x: number = (game.getWidth() - w) / 2;
         const y: number = (game.getHeight() - h) / 2;
 
-        return new ChoiceBubble(game, x, y, w, h, weapons, (weapon) => weapon.displayName, true, 'WEAPON');
+        const currentPower = game.hero.weapon?.power ?? 0;
+        return new ChoiceBubble(game, x, y, w, h, weapons,
+            (weapon, w) => Cheats.weaponStringifier(weapon, w, currentPower), true, 'WEAPON');
     }
 
     static createWarpBubble(game: DwGame): ChoiceBubble<WarpLocation> {

--- a/src/app/dw/ChoiceBubble.spec.ts
+++ b/src/app/dw/ChoiceBubble.spec.ts
@@ -251,6 +251,41 @@ describe('ChoiceBubble', () => {
         });
     });
 
+    describe('ChoiceStringifier contentCharWidth', () => {
+
+        it('passes the content width in characters to the stringifier', () => {
+            const capturedWidths: number[] = [];
+            const stringifier = (choice: string, w: number) => {
+                capturedWidths.push(w);
+                return choice;
+            };
+            // Bubble width 100, xMargin = (1+2+13) * scale = 16, contentWidth = 68, charWidth = 8 → 8 chars
+            const bubble = new ChoiceBubble(game, 0, 0, 100, 100, choices, stringifier);
+            vi.spyOn(game, 'stringWidth').mockReturnValue(8);
+            vi.spyOn(game, 'drawString').mockImplementation(() => undefined);
+            vi.spyOn(game, 'drawStringWithColor').mockImplementation(() => undefined);
+            bubble.paintContent(game.getRenderingContext(), 0, 0);
+            expect(capturedWidths.every((w) => w === 8)).toBe(true);
+            expect(capturedWidths).toHaveLength(choices.length);
+        });
+
+        it('strips color escapes and renders with drawStringWithColor', () => {
+            const stringifier = (choice: string) => `\\c{statIncrease}${choice}\\c`;
+            const bubble = new ChoiceBubble(game, 0, 0, 100, 100, choices, stringifier);
+            vi.spyOn(game, 'stringWidth').mockReturnValue(8);
+            vi.spyOn(game, 'drawString').mockImplementation(() => undefined);
+            const drawSpy = vi.spyOn(game, 'drawStringWithColor').mockImplementation(() => undefined);
+            bubble.paintContent(game.getRenderingContext(), 0, 0);
+            // Every call should pass the clean text and a populated span
+            for (const call of drawSpy.mock.calls) {
+                const [ text, spans ] = call;
+                expect(text).not.toContain('\\c');
+                expect(spans).toHaveLength(1);
+                expect(spans[0].colorId).toEqual('statIncrease');
+            }
+        });
+    });
+
     describe('reset()', () => {
 
         it('resets the selection to the first item', () => {

--- a/src/app/dw/ChoiceBubble.ts
+++ b/src/app/dw/ChoiceBubble.ts
@@ -1,8 +1,8 @@
 import { InputManager } from 'gtp';
-import { Bubble } from './Bubble';
+import { Bubble, ColoredTextSpan } from './Bubble';
 import { DwGame } from './DwGame';
 
-export type ChoiceStringifier<Choice> = (choice: Choice) => string;
+export type ChoiceStringifier<Choice> = (choice: Choice, contentCharWidth: number) => string;
 
 /**
  * A bubble that lets the user choose between several choices. Can optionally be titled
@@ -109,6 +109,9 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
 
         ctx.fillStyle = 'rgb(255,255,255)';
 
+        const charWidth = this.game.stringWidth('x');
+        const contentCharWidth = Math.floor((this.w - 2 * this.getXMargin()) / charWidth);
+
         if (this.columns === 2) {
             const leftCount = Math.ceil(this.choices.length / 2);
             const colGap = this.game.getTileSize();
@@ -127,14 +130,20 @@ export class ChoiceBubble<ChoiceBubbleChoice> extends Bubble {
                         : this.x + Bubble.ARROW_MARGIN;
                     this.drawArrow(arrowX, textY);
                 }
-                this.game.drawString(this.choiceStringifier(choice), textX, textY);
+                const rawText = this.choiceStringifier(choice, contentCharWidth);
+                const spans: ColoredTextSpan[] = [];
+                const text = Bubble.removeSpecialEscapes(rawText, [], spans);
+                this.game.drawStringWithColor(text, spans, textX, textY);
             });
         } else {
             this.choices.forEach((choice, index) => {
                 if (this.curChoice === index) {
                     this.drawArrow(this.x + Bubble.ARROW_MARGIN, y);
                 }
-                this.game.drawString(this.choiceStringifier(choice), x, y);
+                const rawText = this.choiceStringifier(choice, contentCharWidth);
+                const spans: ColoredTextSpan[] = [];
+                const text = Bubble.removeSpecialEscapes(rawText, [], spans);
+                this.game.drawStringWithColor(text, spans, x, y);
                 y += this.yInc;
             });
         }

--- a/src/app/dw/LoadingState.ts
+++ b/src/app/dw/LoadingState.ts
@@ -196,7 +196,13 @@ export class LoadingState extends BaseState {
                 const font: Image = game.assets.get('font');
                 const bitmapFont = new BitmapFont(font, 8, 9, 1, 1, game.scale);
                 bitmapFont.addVariant('blue',
-                    { fromR: 0xff, fromG: 0xff, fromB: 0xff, toR: 0xc0, toG: 0xff, toB: 0xff },
+                    { fromR: 0xff, fromG: 0xff, fromB: 0xff, toR: 0xa0, toG: 0xff, toB: 0xff },
+                );
+                bitmapFont.addVariant('statIncrease',
+                    { fromR: 0xff, fromG: 0xff, fromB: 0xff, toR: 0xa0, toG: 0xff, toB: 0xa0 },
+                );
+                bitmapFont.addVariant('statDecrease',
+                    { fromR: 0xff, fromG: 0xff, fromB: 0xff, toR: 0xff, toG: 0xa0, toB: 0xa0 },
                 );
                 game.assets.set('font', bitmapFont);
 

--- a/src/app/dw/RoamingState.ts
+++ b/src/app/dw/RoamingState.ts
@@ -144,13 +144,13 @@ export class RoamingState extends BaseState {
                     case 'Level Up':
                         this.game.audio.playSound('bump');
                         break;
-                    case 'Weapon Change':
+                    case 'Change Weapon...':
                         this.setSubstate('WEAPON_SELECTION');
                         break;
-                    case 'Armor Change':
+                    case 'Change Armor...':
                         this.setSubstate('ARMOR_SELECTION');
                         break;
-                    case 'Shield Change':
+                    case 'Change Shield...':
                         this.setSubstate('SHIELD_SELECTION');
                         break;
                     case 'Max HP/MP':


### PR DESCRIPTION
## Summary

Shows stat deltas (power for weapons, defense for armor/shields) next to each choice in the equipment cheat bubbles, right-aligned and color-coded: green for improvements, red for downgrades, plain text for no change.

## Details

- Rename cheat menu labels from `Weapon/Armor/Shield Change` to `Change Weapon/Armor/Shield...` (with trailing `...`)
- Add `statIncrease` (#e0ffe0) and `statDecrease` (#ffe0e0) font color variants in `LoadingState`
- Extend `ChoiceStringifier<T>` to receive `contentCharWidth: number` as a second argument, so stringifiers can right-align stat deltas without accessing bubble internals
- Update `ChoiceBubble.paintContent` to parse color escapes via `Bubble.removeSpecialEscapes` and render with `drawStringWithColor` instead of `drawString` — fully backward-compatible since plain strings produce empty spans
- Add `Cheats.weaponStringifier` / `armorStringifier` / `shieldStringifier` static helpers that produce printf-style right-aligned, escape-colored `+N`/`-N` stat deltas relative to the hero's currently equipped item; zero-delta items show only the display name

Closes #124

## Screenshot
<img width="567" height="502" alt="image" src="https://github.com/user-attachments/assets/c49521b6-500b-4019-afae-cae2981da503" />

## Test plan

- [x] Open the cheats menu and verify the three equipment labels read `Change Weapon...`, `Change Armor...`, `Change Shield...`
- [x] With no weapon equipped, open Change Weapon — all deltas should be positive (green)
- [x] Equip the strongest weapon, open Change Weapon — weaker weapons should show negative deltas (red), same-power shows no delta
- [x] Verify same behavior for armor and shields

🤖 Generated with [Claude Code](https://claude.ai/claude-code)